### PR TITLE
update: テスト実行手順を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Linuxでのみ可能。
 ```console
 cmake -S . -B build
 cmake --build build
-ctest --test-dir build
+cd build
+ctest
 ```


### PR DESCRIPTION
GitHub Codespacesの環境では ctest の `--test-dir` オプションが利用できなかった（2022/11/09 現在） 

多くの人がGitHub Codespacesで開発することを考慮して、`--test-dir`オプションを利用しない手順に変更した