### PR TITLE
A3921対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(spirit
 target_sources(spirit
     PUBLIC
     source/MdLed.cpp
+    source/A3921.cpp
 )
 
 enable_testing()

--- a/include/A3921.h
+++ b/include/A3921.h
@@ -1,0 +1,127 @@
+#ifndef SPIRIT_A3921_H
+#define SPIRIT_A3921_H
+
+#include "interfaceDigitalOut.h"
+#include "interfaceMotor.h"
+#include "interfacePwmOut.h"
+
+namespace spirit {
+
+/**
+ * @brief Allegro MicroSystems社製 フルブリッジゲートドライバ A3921 用ドライバ @n
+ * @link  https://www.allegromicro.com/-/media/files/datasheets/a3921-datasheet.pdf
+ * A3921 データシート
+ * @endlink
+ */
+class A3921 {
+public:
+    /**
+     * @enum Decay
+     * @brief モーターの制御方法を設定するための値
+     */
+    enum class Decay {
+        //! Slow decay
+        Slow,
+        //! Mixed decay(未対応)
+        Mixed,
+        //! Fast decay
+        Fast,
+    };
+
+    /**
+     * @brief コンストラクタ
+     * @param sr SR pin
+     * @param pwmh PWMH pin
+     * @param pwml PWML pin
+     * @param phase PHASE pin
+     * @param reset RESET pin
+     */
+    A3921(interfaceDigitalOut& sr, interfacePwmOut& pwmh, interfacePwmOut& pwml, interfacePwmOut& phase,
+          interfaceDigitalOut& reset);
+
+    /**
+     * @brief A3921 を Deep Sleep
+     * @param enabled
+     *      - true : スリープモードを有効にする
+     *      - false: スリープモードを解除する
+     */
+    void sleep(const bool enabled);
+
+    /**
+     * @brief A3921 のリセット機能を実行する
+     * @attention 未実装のため、動作しない
+     */
+    void reset();
+
+    /**
+     * @brief デューティー比を設定する
+     * @remark run() が実行されるまで、 duty_cycle() で設定した値はモーターに対して影響しない
+     * @param value
+     * 設定したいデューティー比
+     * - 範囲: 0.00f <= value <= 1.00F
+     */
+    void duty_cycle(const float value);
+
+    /**
+     * @brief 回転方向を設定する
+     * @remark run() が実行されるまで、 state() で設定した値はモーターに対して影響しない
+     * @param type State::Coast, State::CW, State::CCW, State::Brake のいずれか
+     */
+    void state(const State type);
+
+    /**
+     * @brief Decayを設定する
+     * @remark run() が実行されるまで、decay() で設定した値はモーターに対して影響しない
+     * @param type Decay::Slow, Decay::Fast のいずれか
+     */
+    void decay(const Decay type);
+
+    /**
+     * @brief モーターを設定したデューティー比と回転方向で動かす
+     * @remark run() が実行されるまで、 duty_cycle(), state(), decay() で設定した値はモーターに対して影響しない
+     */
+    void run();
+
+    /**
+     * @brief pwmh, pwml, phase のパルス周期を設定する
+     * @param seconds
+     * 設定したいパルス周期(s)
+     * - 範囲: 0.1s <= seconds <= 1.6666e-5s
+     */
+    void pulse_period(const float seconds);
+
+private:
+    interfaceDigitalOut& _sr;
+    interfacePwmOut&     _pwmh;
+    interfacePwmOut&     _pwml;
+    interfacePwmOut&     _phase;
+    interfaceDigitalOut& _reset;
+
+    float _duty_cycle;
+    State _state;
+    Decay _decay;
+
+    /**
+     * @brief Slow decayとしてモータを動かす
+     * @details
+     * A3921 データシートの以下の制御を実施する
+     *      - Figure 1: Slow Decay Power Bridge Current Paths
+     *          - (C) Slow decay, SR active, low-side PWM
+     */
+    void run_slow_decay();
+
+    /**
+     * @brief Fast decayとしてモータを動かす
+     * @details
+     * A3921 データシートの以下の制御を実施する
+     *      - Figure 2: Fast Decay Power Bridge Current Paths
+     *          - (B) Fast decay, SR active, full four-quadrant control
+     */
+    void run_fast_decay();
+
+    static constexpr Decay default_decay = Decay::Slow;
+};
+
+}  // namespace spirit
+
+#endif  // SPIRIT_A3921_H

--- a/include/interfaceDigitalOut.h
+++ b/include/interfaceDigitalOut.h
@@ -1,0 +1,17 @@
+#ifndef SPIRIT_INTERFACE_DIGITALOUT_H
+#define SPIRIT_INTERFACE_DIGITALOUT_H
+
+#include <cstdint>
+
+namespace spirit {
+
+class interfaceDigitalOut {
+public:
+    virtual void write(const uint32_t value) = 0;
+
+    virtual uint32_t read() const = 0;
+};
+
+}  // namespace spirit
+
+#endif  //SPIRIT_INTERFACE_DIGITALOUT_H

--- a/include/interfaceMotor.h
+++ b/include/interfaceMotor.h
@@ -4,12 +4,11 @@
 namespace spirit {
 
 enum class State {
-    Begin = 0,
-    Free  = Begin,
+    Free = 0,
+    Coast = Free,
     CW,   // Clock Wise
     CCW,  // Counter Clock Wise
     Brake,
-    End = Brake,
 };
 
 /** A Motor is abstract base class for moving the motor

--- a/include/interfaceMotor.h
+++ b/include/interfaceMotor.h
@@ -4,7 +4,7 @@
 namespace spirit {
 
 enum class State {
-    Free = 0,
+    Free  = 0,
     Coast = Free,
     CW,   // Clock Wise
     CCW,  // Counter Clock Wise

--- a/include/interfacePwmOut.h
+++ b/include/interfacePwmOut.h
@@ -1,0 +1,19 @@
+#ifndef SPIRIT_INTERFACE_PWMOUT_H
+#define SPIRIT_INTERFACE_PWMOUT_H
+
+#include <cstdint>
+
+namespace spirit {
+
+class interfacePwmOut {
+public:
+    virtual void write(const float value) = 0;
+
+    virtual float read() const = 0;
+
+    virtual void period(const float seconds) = 0;
+};
+
+}  // namespace spirit
+
+#endif  //SPIRIT_INTERFACE_PWMOUT_H

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -1,0 +1,175 @@
+#include "A3921.h"
+
+namespace spirit {
+
+A3921::A3921(interfaceDigitalOut& sr, interfacePwmOut& pwmh, interfacePwmOut& pwml, interfacePwmOut& phase,
+             interfaceDigitalOut& reset)
+    : _sr(sr),
+      _pwmh(pwmh),
+      _pwml(pwml),
+      _phase(phase),
+      _reset(reset),
+      _duty_cycle(0.00F),
+      _state(interfaceMotor::default_state),
+      _decay(default_decay)
+{
+    sleep(false);
+    run();
+}
+
+void A3921::sleep(const bool enabled)
+{
+    if (enabled) {
+        _reset.write(0U);
+    } else {
+        _reset.write(1U);
+    }
+}
+
+void A3921::reset()
+{
+    _reset.write(1);
+    // TODO time時間待つ (0.1us < time < 3.5us)
+    _reset.write(0);
+}
+
+void A3921::duty_cycle(const float value)
+{
+    if ((0.00F < value) && (value < 1.00F)) {
+        _duty_cycle = value;
+    }
+}
+
+void A3921::state(const State type)
+{
+    switch (type) {
+        case State::Free:
+        case State::CW:
+        case State::CCW:
+        case State::Brake:
+            break;
+        default:
+            return;
+    }
+
+    _state = type;
+}
+
+void A3921::decay(const Decay type)
+{
+    switch (type) {
+        case Decay::Slow:
+        case Decay::Fast:
+            break;
+
+        // 非対応
+        case Decay::Mixed:
+        default:
+            return;
+    }
+
+    _decay = type;
+}
+
+void A3921::run()
+{
+    switch (_decay) {
+        case Decay::Slow:
+            run_slow_decay();
+            break;
+
+        case Decay::Fast:
+            run_fast_decay();
+            break;
+
+        case Decay::Mixed:
+        default:
+            return;
+    }
+}
+
+void A3921::run_slow_decay()
+{
+    switch (_state) {
+        case State::Free:
+            _sr.write(0);
+            _pwmh.write(0.00F);
+            _pwml.write(0.00F);
+            _phase.write(0.00F);
+            break;
+
+        case State::CW:
+            // a to b
+            _sr.write(1);
+            _pwmh.write(_duty_cycle);
+            _pwml.write(1.00F);
+            _phase.write(1.00F);
+            break;
+
+        case State::CCW:
+            // b to a
+            _sr.write(1);
+            _pwmh.write(_duty_cycle);
+            _pwml.write(1.00F);
+            _phase.write(0.00F);
+            break;
+
+        case State::Brake:
+            _sr.write(0);
+            _pwmh.write(0.00F);
+            _pwml.write(1.00F);
+            _phase.write(0.00F);
+            break;
+
+        default:
+            break;
+    }
+}
+
+void A3921::run_fast_decay()
+{
+    switch (_state) {
+        case State::Free:
+            _sr.write(0);
+            _pwmh.write(0.00F);
+            _pwml.write(0.00F);
+            _phase.write(0.00F);
+            break;
+
+        case State::CW:
+            // a to b
+            _sr.write(0);
+            _pwmh.write(1.00F);
+            _pwml.write(1.00F);
+            _phase.write(0.50F + (_duty_cycle / 2.0F));
+            break;
+
+        case State::CCW:
+            // b to a
+            _sr.write(0);
+            _pwmh.write(1.00F);
+            _pwml.write(1.00F);
+            _phase.write(0.50F - (_duty_cycle / 2.0F));
+            break;
+
+        case State::Brake:
+            _sr.write(0);
+            _pwmh.write(0.00F);
+            _pwml.write(1.00F);
+            _phase.write(0.00F);
+            break;
+
+        default:
+            break;
+    }
+}
+
+void A3921::pulse_period(float seconds)
+{
+    if ((interfaceMotor::min_pulse_period <= seconds) && (seconds <= interfaceMotor::max_pulse_period)) {
+        _pwmh.period(seconds);
+        _pwml.period(seconds);
+    }
+}
+
+}  // namespace spirit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,11 @@ add_executable(test_mdled test_MdLed.cpp)
 target_include_directories(test_mdled PUBLIC ../include)
 target_link_libraries(test_mdled PRIVATE gtest_main spirit)
 
+add_executable(test_a3921 test_A3921.cpp)
+target_include_directories(test_mdled PUBLIC ../include)
+target_link_libraries(test_a3921 PRIVATE gtest_main spirit)
+
 # CTestへ単体テストを登録
 include(GoogleTest)
 gtest_discover_tests(test_mdled)
+gtest_discover_tests(test_a3921)

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "A3921.h"
+
+using namespace spirit;
+
+class testDigitalOut : public interfaceDigitalOut {
+public:
+    void write(const uint32_t value) override
+    {
+        _value = value;
+    }
+
+    uint32_t read() const override
+    {
+        return _value;
+    }
+
+private:
+    uint32_t _value;
+};
+
+class testPwmOut : public interfacePwmOut {
+public:
+    void write(const float value) override
+    {
+        _value = value;
+    }
+
+    float read() const override
+    {
+        return _value;
+    }
+
+    void period(const float seconds) override
+    {
+        _period = seconds;
+    }
+
+private:
+    float _value;
+    float _period;
+};
+
+/**
+ * @brief A3921 が Brake 状態であるかを返す
+ * @param pwmh PWMH pin
+ * @param pwml PWML pin
+ * @retval true Brake 状態
+ * @retval false 非 Brake 状態
+ */
+bool isBrake(testPwmOut& pwmh, testPwmOut& pwml)
+{
+    if (((fabsf(pwmh.read() - 1.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 0.00F) < FLT_EPSILON)) ||
+        ((fabsf(pwmh.read() - 0.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 1.00F) < FLT_EPSILON))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * @brief A3921 が Coast 状態であるかを返す
+ * @param pwmh PWMH pin
+ * @param pwml PWML pin
+ * @retval true Coast 状態
+ * @retval false 非 Coast 状態
+ */
+bool isCoast(testPwmOut& pwmh, testPwmOut& pwml)
+{
+    if ((fabsf(pwmh.read() - 0.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 0.00F) < FLT_EPSILON)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * @brief 初期値のテスト
+ * - sleep モード: OFF
+ * - モーター: Brake
+ */
+TEST(A3921, InitValueTest)
+{
+    testDigitalOut sr;
+    testPwmOut     pwmh;
+    testPwmOut     pwml;
+    testPwmOut     phase;
+    testDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    EXPECT_EQ(reset.read(), 1);
+
+    EXPECT_TRUE(isBrake(pwmh, pwml));
+}
+
+/**
+ * @brief スリープ機能のテスト
+ * @details A3921 は RESET pin にLow(0) を入力することで、Sleep モードに移行する。
+ */
+TEST(A3921, SleepTest)
+{
+    testDigitalOut sr;
+    testPwmOut     pwmh;
+    testPwmOut     pwml;
+    testPwmOut     phase;
+    testDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    a3921.sleep(true);
+    EXPECT_EQ(reset.read(), 0);
+
+    a3921.sleep(false);
+    EXPECT_EQ(reset.read(), 1);
+}
+
+/**
+ * @brief リセット機能のテスト(未実装のため、テストはスキップする)
+ */
+TEST(A3921, ResetTest)
+{
+    testDigitalOut sr;
+    testPwmOut     pwmh;
+    testPwmOut     pwml;
+    testPwmOut     phase;
+    testDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    GTEST_SKIP_("Not implemented because the Reset function is not yet supported.");
+    // TODO 未実装のため、実装時に行うであろうフローのイメージを記述
+    // timer.start();
+    // a3921.reset();
+    // timer.stop();
+    // EXPECT_LE(0.35us, timer.read());
+}
+
+/**
+ * @brief Slow decay でのモーター制御のテスト
+ * @details  spirit::A3921::duty_cycle() に0.50Fを入力することで、Coast/Brake 状態になったときに
+ * pwmh, pwml が意図した出力(0.50F以外)になっていることを確認する
+ */
+TEST(A3921, SlowDecayTest)
+{
+    testDigitalOut sr;
+    testPwmOut     pwmh;
+    testPwmOut     pwml;
+    testPwmOut     phase;
+    testDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    // 共通の設定
+    a3921.decay(A3921::Decay::Slow);
+    a3921.duty_cycle(0.50F);
+
+    // Coast
+    a3921.state(State::Coast);
+    a3921.run();
+
+    EXPECT_TRUE(isCoast(pwmh, pwml));
+
+    // CW
+    a3921.state(State::CW);
+    a3921.run();
+
+    EXPECT_EQ(sr.read(), 1);
+    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(phase.read(), 1.00F);
+
+    // CCW
+    a3921.state(State::CCW);
+    a3921.run();
+
+    EXPECT_EQ(sr.read(), 1);
+    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(phase.read(), 0.00F);
+
+    // Brake
+    a3921.state(State::Brake);
+    a3921.run();
+
+    EXPECT_TRUE(isBrake(pwmh, pwml));
+}
+
+/**
+ * @brief Fast decay でのモーター制御のテスト
+ * @details  spirit::A3921::duty_cycle() に0.50Fを入力することで、Coast/Brake 状態になったときに
+ * pwmh, pwml が意図した出力(0.50F以外)になっていることを確認する
+ */
+TEST(A3921, FastDecayTest)
+{
+    testDigitalOut sr;
+    testPwmOut     pwmh;
+    testPwmOut     pwml;
+    testPwmOut     phase;
+    testDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    // 共通の設定
+    a3921.decay(A3921::Decay::Fast);
+    a3921.duty_cycle(0.50F);
+
+    // Coast
+    a3921.state(State::Coast);
+    a3921.run();
+
+    EXPECT_TRUE(isCoast(pwmh, pwml));
+
+    // CW
+    a3921.state(State::CW);
+    a3921.run();
+
+    EXPECT_EQ(sr.read(), 0);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(phase.read(), 0.75F);
+
+    // CCW
+    a3921.state(State::CCW);
+    a3921.run();
+
+    EXPECT_EQ(sr.read(), 0);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(phase.read(), 0.25F);
+
+    // Brake
+    a3921.state(State::Brake);
+    a3921.run();
+
+    EXPECT_TRUE(isBrake(pwmh, pwml));
+}


### PR DESCRIPTION
**Issue**

- #17

**対応内容**

A3921用のドライバを追加しました

**テスト**

A3921の動作全般のテストを追加しています

**残作業**

時間測定の関数が必要なため、Reset機能は対応していません

Reset機能は前のライブラリでも利用していないため、(少なくとも現在は)対応は必要ないと思います