### PR TITLE
fix: 初期状態でGitが使えない問題を解決 #24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 				"EditorConfig.EditorConfig"
 			]
 		}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -25,7 +25,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "gcc -v",
+	"postCreateCommand": "git config --global --add safe.directory /workspaces/*"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
**Issue**

- #24 

**対応内容**

Dev Contaierの構築の最後に `git config --global --add safe.directory /workspaces/*` を実行させてい解決した

**テスト**

Dev Contaierに関する不具合修正なのでテストの必要はない

**残作業**

特になし
