### PR TITLE
fix: Initialize member variables of `stub.cpp`

### DIFF
--- a/tests/stubs.h
+++ b/tests/stubs.h
@@ -19,7 +19,7 @@ public:
     }
 
 private:
-    uint32_t _value;
+    uint32_t _value{0};
 };
 
 class StubPwmOut : public interfacePwmOut {
@@ -40,8 +40,8 @@ public:
     }
 
 private:
-    float _value;
-    float _period;
+    float _value{0.00F};
+    float _period{0.00F};
 };
 
 }  // namespace spirit


### PR DESCRIPTION
**Issue**

- なし

**対応内容**

`stub.cpp`内のクラスのメンバ変数を初期化していなかったので、初期化した

**テスト**

Stubなので特になし

**残作業**

なし
