### PR TITLE
Add: A3921のパルス周期に着目したテストを追加する

### DIFF
--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -7,6 +7,9 @@ A3921::A3921(interfaceDigitalOut& sr, interfacePwmOut& pwmh, interfacePwmOut& pw
     : _sr(sr), _pwmh(pwmh), _pwml(pwml), _phase(phase), _reset(reset)
 {
     sleep(false);
+    _pwmh.period(interfaceMotor::default_pulse_period);
+    _pwml.period(interfaceMotor::default_pulse_period);
+    _phase.period(interfaceMotor::default_pulse_period);
     run();
 }
 
@@ -162,6 +165,7 @@ void A3921::pulse_period(const float seconds)
     if ((interfaceMotor::min_pulse_period <= seconds) && (seconds <= interfaceMotor::max_pulse_period)) {
         _pwmh.period(seconds);
         _pwml.period(seconds);
+        _phase.period(seconds);
     }
 }
 

--- a/tests/stubs.h
+++ b/tests/stubs.h
@@ -39,6 +39,11 @@ public:
         _period = seconds;
     }
 
+    float read_period()
+    {
+        return _period;
+    }
+
 private:
     float _value{0.00F};
     float _period{0.00F};

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -35,15 +35,16 @@ bool isCoast(const StubPwmOut& pwmh, const StubPwmOut& pwml)
 {
     if ((fabsf(pwmh.read() - 0.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 0.00F) < FLT_EPSILON)) {
         return true;
-    } else {
-        return false;
     }
+
+    return false;
 }
 
 /**
  * @brief 初期値のテスト
  * - sleep モード: OFF
  * - モーター: Brake
+ * - パルス周期: interfaceMotor::default_pulse_period
  */
 TEST(A3921, InitValueTest)
 {
@@ -55,6 +56,9 @@ TEST(A3921, InitValueTest)
     A3921          a3921(sr, pwmh, pwml, phase, reset);
 
     EXPECT_EQ(reset.read(), 1);
+    EXPECT_FLOAT_EQ(pwmh.read_period(), interfaceMotor::default_pulse_period);
+    EXPECT_FLOAT_EQ(pwml.read_period(), interfaceMotor::default_pulse_period);
+    EXPECT_FLOAT_EQ(phase.read_period(), interfaceMotor::default_pulse_period);
 
     EXPECT_TRUE(isBrake(pwmh, pwml));
 }
@@ -195,4 +199,25 @@ TEST(A3921, FastDecayTest)
     a3921.run();
 
     EXPECT_TRUE(isBrake(pwmh, pwml));
+}
+
+/**
+ * @brief パルス周期の設定テスト
+ */
+TEST(A3921, PulsePeriodTest)
+{
+    StubDigitalOut sr;
+    StubPwmOut     pwmh;
+    StubPwmOut     pwml;
+    StubPwmOut     phase;
+    StubDigitalOut reset;
+    A3921          a3921(sr, pwmh, pwml, phase, reset);
+
+    // interfaceMotor::default_pulse_period と異なる値を設定するため、 0.005Fを加える
+    float pulse_period = interfaceMotor::default_pulse_period + 0.005F;
+    a3921.pulse_period(pulse_period);
+
+    EXPECT_FLOAT_EQ(pwmh.read_period(), pulse_period);
+    EXPECT_FLOAT_EQ(pwml.read_period(), pulse_period);
+    EXPECT_FLOAT_EQ(phase.read_period(), pulse_period);
 }


### PR DESCRIPTION
**Issue**

- なし

**対応内容**

A3921のパルス周期に着目したテストを追加しました

また、必要なテストの追加に伴い実装にいくつか手を加えました
- `StubPwmOut` クラスにパルス周期を得る `read_period()` を追加
- A3921の初期化時に、パルス周期を設定する
- `A3921::pulse_period()` 中で、PHASEピンにパルス周期を設定する

**テスト**

以下のテストを追加した
- A3921の初期化時にパルス周期を意図した値で設定しているかのテスト
- `A3921::pulse_period()` でPWMHピン、PWMLピン、PHASEピンのパルス周期が変わっていることのテスト

**残作業**

特になし
