### PR TITLE
update: Eliminate duty ratio range checks

### DIFF
--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -31,9 +31,7 @@ void A3921::reset()
 
 void A3921::duty_cycle(const float value)
 {
-    if ((0.00F < value) && (value < 1.00F)) {
-        _duty_cycle = value;
-    }
+    _duty_cycle = value;
 }
 
 void A3921::state(const State type)


### PR DESCRIPTION
**Issue**
- #35

**対応内容**
Issueで提案した範囲チェックの廃止を行いました

**テスト**
範囲チェックを行っているか/行っていないかの確認はわざわざすることではないと思うので、行っていません

また、テスト用のスタブもMbedのようにデューティー比が1.00より多ければ1.00にする必要もないと判断した

**残作業**
なし
