### PR TITLE
changes:Slow DecayのPWMをlow sideに変更#37

### DIFF
--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -95,16 +95,16 @@ void A3921::run_slow_decay()
         case State::CW:
             // a to b
             _sr.write(1);
-            _pwmh.write(_duty_cycle);
-            _pwml.write(1.00F);
+            _pwmh.write(1.00F);
+            _pwml.write(_duty_cycle);
             _phase.write(1.00F);
             break;
 
         case State::CCW:
             // b to a
             _sr.write(1);
-            _pwmh.write(_duty_cycle);
-            _pwml.write(1.00F);
+            _pwmh.write(1.00F);
+            _pwml.write(_duty_cycle);
             _phase.write(0.00F);
             break;
 

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -132,8 +132,8 @@ TEST(A3921, SlowDecayTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
-    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
     EXPECT_FLOAT_EQ(phase.read(), 1.00F);
 
     // CCW
@@ -141,8 +141,8 @@ TEST(A3921, SlowDecayTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
-    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
     EXPECT_FLOAT_EQ(phase.read(), 0.00F);
 
     // Brake


### PR DESCRIPTION
**Issue**

- #37 

**対応内容**

SlowDecayのPWMをHigh sideからLow sideに変更

**テスト**

PWMをかける場所がHigh sideからLow sideに変更になったため確認内容を変更

**残作業**

汎用性を持たせるためPWMをかけるサイドを切り替える機能の実装