### PR TITLE
Add:Slow decay のPwm side を切り替える機能の追加。

### DIFF
--- a/include/A3921.h
+++ b/include/A3921.h
@@ -29,6 +29,17 @@ public:
     };
 
     /**
+     * @enum PwmSide
+     * @brief Slow decayのPWM sideを設定するための値
+     */
+    enum class PwmSide:uint8_t {
+        /// Low side
+        Low,
+        /// High side
+        High,
+    };
+
+    /**
      * @brief コンストラクタ
      * @param sr SR pin
      * @param pwmh PWMH pin
@@ -77,6 +88,13 @@ public:
     void decay(Decay type);
 
     /**
+     * @brief Slow DecayのPWM sideを設定する
+     * @remark run() が実行されるまで、decay() で設定した値はモーターに対して影響しない
+     * @param type PwmSide::Low, PwmSide::High のいずれか
+     */
+    void pwm_side(PwmSide type);
+
+    /**
      * @brief モーターを設定したデューティー比と回転方向で動かす
      * @remark run() が実行されるまで、 duty_cycle(), state(), decay() で設定した値はモーターに対して影響しない
      */
@@ -97,9 +115,10 @@ private:
     InterfacePwmOut&     _phase;
     InterfaceDigitalOut& _reset;
 
-    float _duty_cycle{0.00F};
-    State _state{InterfaceMotor::default_state};
-    Decay _decay{default_decay};
+    float   _duty_cycle{0.00F};
+    State   _state{InterfaceMotor::default_state};
+    Decay   _decay{default_decay};
+    PwmSide _pwm_side{default_pwm_side};
 
     /**
      * @brief Slow decayとしてモータを動かす
@@ -119,7 +138,8 @@ private:
      */
     void run_fast_decay();
 
-    static constexpr Decay default_decay = Decay::Slow;
+    static constexpr Decay   default_decay    = Decay::Slow;
+    static constexpr PwmSide default_pwm_side = PwmSide::Low;
 };
 
 }  // namespace spirit

--- a/include/A3921.h
+++ b/include/A3921.h
@@ -32,7 +32,7 @@ public:
      * @enum PwmSide
      * @brief Slow decayのPWM sideを設定するための値
      */
-    enum class PwmSide:uint8_t {
+    enum class PwmSide : uint8_t {
         /// Low side
         Low,
         /// High side

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -65,6 +65,19 @@ void A3921::decay(const Decay type)
     _decay = type;
 }
 
+void A3921::pwm_side(PwmSide type)
+{
+    switch(type){
+        case PwmSide::Low:
+        case PwmSide::High:
+            break;
+        default:
+            return;
+    }
+
+    _pwm_side = type;
+}
+
 void A3921::run()
 {
     switch (_decay) {
@@ -84,6 +97,22 @@ void A3921::run()
 
 void A3921::run_slow_decay()
 {
+    float pwm_low_side;
+    float pwm_high_side;
+
+    switch(_pwm_side) {
+        case PwmSide::Low:
+            pwm_low_side  = _duty_cycle;
+            pwm_high_side = 1.00F;
+            break;
+        case PwmSide::High:
+            pwm_low_side  = 1.00F;
+            pwm_high_side = _duty_cycle;
+            break;
+        default:
+            return;
+    }
+
     switch (_state) {
         case State::Coast:
             _sr.write(0);
@@ -95,16 +124,16 @@ void A3921::run_slow_decay()
         case State::CW:
             // a to b
             _sr.write(1);
-            _pwmh.write(1.00F);
-            _pwml.write(_duty_cycle);
+            _pwmh.write(pwm_high_side);
+            _pwml.write(pwm_low_side);
             _phase.write(1.00F);
             break;
 
         case State::CCW:
             // b to a
             _sr.write(1);
-            _pwmh.write(1.00F);
-            _pwml.write(_duty_cycle);
+            _pwmh.write(pwm_high_side);
+            _pwml.write(pwm_low_side);
             _phase.write(0.00F);
             break;
 

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -67,7 +67,7 @@ void A3921::decay(const Decay type)
 
 void A3921::pwm_side(PwmSide type)
 {
-    switch(type){
+    switch (type) {
         case PwmSide::Low:
         case PwmSide::High:
             break;
@@ -100,7 +100,7 @@ void A3921::run_slow_decay()
     float pwm_low_side;
     float pwm_high_side;
 
-    switch(_pwm_side) {
+    switch (_pwm_side) {
         case PwmSide::Low:
             pwm_low_side  = _duty_cycle;
             pwm_high_side = 1.00F;

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -95,16 +95,16 @@ void A3921::run_slow_decay()
         case State::CW:
             // a to b
             _sr.write(1);
-            _pwmh.write(_duty_cycle);
-            _pwml.write(1.00F);
+            _pwmh.write(1.00F);
+            _pwml.write(_duty_cycle);
             _phase.write(1.00F);
             break;
 
         case State::CCW:
             // b to a
             _sr.write(1);
-            _pwmh.write(_duty_cycle);
-            _pwml.write(1.00F);
+            _pwmh.write(1.00F);
+            _pwml.write(_duty_cycle);
             _phase.write(0.00F);
             break;
 

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -132,8 +132,8 @@ TEST(A3921, SlowDecayTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
-    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
     EXPECT_FLOAT_EQ(phase.read(), 1.00F);
 
     // CCW
@@ -141,8 +141,8 @@ TEST(A3921, SlowDecayTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
-    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
+    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
     EXPECT_FLOAT_EQ(phase.read(), 0.00F);
 
     // Brake

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -183,8 +183,8 @@ TEST(A3921, SlowDecayHighSideTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
-    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
     EXPECT_FLOAT_EQ(phase.read(), 1.00F);
 
     // CCW
@@ -192,8 +192,8 @@ TEST(A3921, SlowDecayHighSideTest)
     a3921.run();
 
     EXPECT_EQ(sr.read(), 1);
-    EXPECT_FLOAT_EQ(pwmh.read(), 1.00F);
-    EXPECT_FLOAT_EQ(pwml.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwmh.read(), 0.50F);
+    EXPECT_FLOAT_EQ(pwml.read(), 1.00F);
     EXPECT_FLOAT_EQ(phase.read(), 0.00F);
 
     // Brake


### PR DESCRIPTION
**Issue**

- #44 

**対応内容**

Slow decay のPwm side を切り替える機能の追加。

**テスト**

slow decay のテストをLow side と High side 用で分けて作成

**残作業**

#include <gtest/gtest.h>が通らず、テストの実行が出来ないため確認お願いします。
