### PR TITLE
fix: いくつかの軽微な修正

### DIFF
--- a/include/InterfaceMotor.h
+++ b/include/InterfaceMotor.h
@@ -38,7 +38,7 @@ public:
     virtual                 operator State() const  = 0;
 
     static constexpr State default_state        = State::Brake;
-    static constexpr float default_pulse_period = 0.000'02F;  // 5.0kHz
+    static constexpr float default_pulse_period = 1.0F / 5'000.0F;
     static constexpr float min_pulse_period     = 1.0F / 60'000.0F;
     static constexpr float max_pulse_period     = 1.0F / 10.0F;
 };

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -16,9 +16,9 @@ A3921::A3921(InterfaceDigitalOut& sr, InterfacePwmOut& pwmh, InterfacePwmOut& pw
 void A3921::sleep(const bool enabled)
 {
     if (enabled) {
-        _reset.write(0U);
+        _reset.write(0);
     } else {
-        _reset.write(1U);
+        _reset.write(1);
     }
 }
 

--- a/tests/test_A3921.cpp
+++ b/tests/test_A3921.cpp
@@ -14,7 +14,7 @@ using namespace spirit;
  * @retval true Brake 状態
  * @retval false 非 Brake 状態
  */
-bool isBrake(const StubPwmOut& pwmh, const StubPwmOut& pwml)
+bool is_brake(const StubPwmOut& pwmh, const StubPwmOut& pwml)
 {
     if (((fabsf(pwmh.read() - 1.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 0.00F) < FLT_EPSILON)) ||
         ((fabsf(pwmh.read() - 0.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 1.00F) < FLT_EPSILON))) {
@@ -31,7 +31,7 @@ bool isBrake(const StubPwmOut& pwmh, const StubPwmOut& pwml)
  * @retval true Coast 状態
  * @retval false 非 Coast 状態
  */
-bool isCoast(const StubPwmOut& pwmh, const StubPwmOut& pwml)
+bool is_coast(const StubPwmOut& pwmh, const StubPwmOut& pwml)
 {
     if ((fabsf(pwmh.read() - 0.00F) < FLT_EPSILON) && (fabsf(pwml.read() - 0.00F) < FLT_EPSILON)) {
         return true;
@@ -60,7 +60,7 @@ TEST(A3921, InitValueTest)
     EXPECT_FLOAT_EQ(pwml.read_period(), InterfaceMotor::default_pulse_period);
     EXPECT_FLOAT_EQ(phase.read_period(), InterfaceMotor::default_pulse_period);
 
-    EXPECT_TRUE(isBrake(pwmh, pwml));
+    EXPECT_TRUE(is_brake(pwmh, pwml));
 }
 
 /**
@@ -126,7 +126,7 @@ TEST(A3921, SlowDecayLowSideTest)
     a3921.state(State::Coast);
     a3921.run();
 
-    EXPECT_TRUE(isCoast(pwmh, pwml));
+    EXPECT_TRUE(is_coast(pwmh, pwml));
 
     // CW
     a3921.state(State::CW);
@@ -150,7 +150,7 @@ TEST(A3921, SlowDecayLowSideTest)
     a3921.state(State::Brake);
     a3921.run();
 
-    EXPECT_TRUE(isBrake(pwmh, pwml));
+    EXPECT_TRUE(is_brake(pwmh, pwml));
 }
 
 /**
@@ -176,7 +176,7 @@ TEST(A3921, SlowDecayHighSideTest)
     a3921.state(State::Coast);
     a3921.run();
 
-    EXPECT_TRUE(isCoast(pwmh, pwml));
+    EXPECT_TRUE(is_coast(pwmh, pwml));
 
     // CW
     a3921.state(State::CW);
@@ -200,7 +200,7 @@ TEST(A3921, SlowDecayHighSideTest)
     a3921.state(State::Brake);
     a3921.run();
 
-    EXPECT_TRUE(isBrake(pwmh, pwml));
+    EXPECT_TRUE(is_brake(pwmh, pwml));
 }
 
 /**
@@ -225,7 +225,7 @@ TEST(A3921, FastDecayTest)
     a3921.state(State::Coast);
     a3921.run();
 
-    EXPECT_TRUE(isCoast(pwmh, pwml));
+    EXPECT_TRUE(is_coast(pwmh, pwml));
 
     // CW
     a3921.state(State::CW);
@@ -249,7 +249,7 @@ TEST(A3921, FastDecayTest)
     a3921.state(State::Brake);
     a3921.run();
 
-    EXPECT_TRUE(isBrake(pwmh, pwml));
+    EXPECT_TRUE(is_brake(pwmh, pwml));
 }
 
 /**


### PR DESCRIPTION
**Issue**
軽微な修正なのでなし

**対応内容**
- include/InterfaceMotor.h
  - default_pulse_period の値をわかりやすい表に気変更
- source/A3921.cpp
  - 接尾辞のUがついているものがあったので、削除
- tests/test_A3921.cpp
  - isBrake() → is_brake()
  - isCoast() → is_coast()

**テスト**
構造に変化を及ぼさないのでなし

**残作業**
なし
