### PR TITLE
update: Encoding を UTF-8 にする設定を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
-  "files.exclude": {
-    "build/": true
-},
-"cmake.configureOnOpen": true,
-"C_Cpp.clang_format_sortIncludes": true,
-"C_Cpp.clang_format_style": "file",
-"C_Cpp.default.cppStandard": "c++14",
-"C_Cpp.doxygen.generatedStyle": "/**",
-"C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
+    "files.exclude": {
+        "build/": true
+    },
+    "cmake.configureOnOpen": true,
+    "C_Cpp.clang_format_sortIncludes": true,
+    "C_Cpp.clang_format_style": "file",
+    "C_Cpp.default.cppStandard": "c++14",
+    "C_Cpp.doxygen.generatedStyle": "/**",
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "files.encoding": "utf8"
 }


### PR DESCRIPTION
**Issue**

- なし

**対応内容**

User や Remote にFileEncoding の設定があると、本リポジトリ内はすべてUTF-8であるにもかかわらず、そちらの設定が優先されてしまう。

そのため、最優先となる Work space で UTF-8 に設定することで、上記の問題が発生しないようにする

**テスト**

設定の変更なので、テストの追加/変更の必要なし

**残作業**

特になし
