### PR TITLE
Fix: deploy時にsubmoduleを持ってくる

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Run doxygen


### PR DESCRIPTION
**Issue**

- なし

**対応内容**

以下のPullRequestで`doxygen-awesome-css`をサブモジュールとして追加したが、[deploy-static.yml](https://github.com/yutotnh/spirit/blob/main/.github/workflows/deploy-static.yml)が失敗するようになってしまった
アクション内でサブモジュールを持ってくる設定を行い、デプロイに成功させる
- #81

**テスト**

ドキュメントの変更なのでなし

**残作業**

なし
