### PR TITLE
update: CAN通信の場合のIDを返す関数を追加した  #91

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,13 @@ target_include_directories(spirit
 
 target_sources(spirit
     PUBLIC
-    source/bit.cpp
-    source/Motor.cpp
-    source/CANMessage.cpp
-    source/PwmDataConverter.cpp
-    source/MdLed.cpp
     source/A3921.cpp
+    source/bit.cpp
+    source/CANMessage.cpp
+    source/Id.cpp
+    source/MdLed.cpp
+    source/Motor.cpp
+    source/PwmDataConverter.cpp
 )
 
 enable_testing()

--- a/include/Id.h
+++ b/include/Id.h
@@ -1,0 +1,29 @@
+#ifndef SPIRIT_ID
+#define SPIRIT_ID
+
+#include <cstddef>
+#include <cstdint>
+
+namespace spirit {
+
+namespace can {
+static constexpr uint32_t can_id_size = 11;
+
+static constexpr uint32_t motor_prefix      = 0x1;
+static constexpr uint32_t motor_prefix_size = 2;
+static constexpr uint32_t dip_switch_size   = 5;
+
+/**
+ * @brief CAN通信時のモーターIDを取得する
+ * @param motor_count 基板にあるモーターの数
+ * @param dip_switch DIPスイッチの値(0x0-0xF)
+ * @param motor モーター番号
+ * @return CAN通信時のモーターID(0の場合、エラー)
+ */
+uint32_t get_motor_id(uint32_t motor_count, uint32_t motor, uint32_t dip_switch);
+
+}  // namespace can
+
+}  // namespace spirit
+
+#endif  // SPIRIT_ID

--- a/source/Id.cpp
+++ b/source/Id.cpp
@@ -1,0 +1,103 @@
+#include "Id.h"
+
+namespace spirit {
+
+namespace can {
+
+namespace {
+
+/**
+ * @brief
+ * @param dip_switch_size
+ * @return
+ */
+bool dip_switch_is_valid(uint32_t dip_switch, std::size_t dip_switch_size)
+{
+    // DIPスイッチの値がビット幅を超えていないかチェックする
+    // 例えば、DIPスイッチの値が0b1111で、ビット幅が3の場合、0b1111は3bitで表現できないため、エラーとする
+    return (dip_switch >> dip_switch_size) == 0;
+}
+
+bool motor_is_valid(uint32_t motor, uint32_t motor_count)
+{
+    // モーター番号がモーターの数を超えていないかチェックする
+    // 例えば、モーターの数が2で、モーター番号が2の場合、モーター番号は0-1であるため、エラーとする
+    return motor < motor_count;
+}
+
+}  // namespace
+
+uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const uint32_t dip_switch)
+{
+    uint32_t id = 0;
+    id          = motor_prefix << (can_id_size - motor_prefix_size);
+
+    constexpr uint32_t motor_count_prefix_size = 2;
+
+    if (motor_is_valid(motor, motor_count) == false) {
+        return 0;
+    }
+
+    if (dip_switch_is_valid(dip_switch, dip_switch_size) == false) {
+        return 0;
+    }
+
+    // motor_countの値によって、データを決定する
+    // - motor_count = 1: 0b00
+    // - motor_count = 2: 0b01
+    // - motor_count = 3: 0b10 // 3つの場合、表現に必要なビットは2bitであるため、4つの場合と同じになる
+    // - motor_count = 4: 0b10
+    uint32_t type = 0;
+
+    if (motor_count == 1) {
+        type = 0;
+    } else if (motor_count <= 2) {
+        type = 1;
+    } else if (motor_count <= 4) {
+        type = 2;
+    } else {
+        return 0;
+    }
+
+    switch (type) {
+        case 0:
+            // 基板のモータは1つであることを示す
+            id |= 0x00 << (can_id_size - motor_prefix_size - motor_count_prefix_size);
+
+            // DIPスイッチの値をそのままIDに反映する
+            id |= dip_switch << (can_id_size - motor_prefix_size - motor_count_prefix_size - dip_switch_size);
+
+            return id;
+        case 1:
+            // 基板のモータは2つであることを示す
+            id |= 0x01 << (can_id_size - motor_prefix_size - motor_count_prefix_size);
+
+            // どちらのモーターかを示す(1はmotorの値が0-1であり、どのmotorかを1bitで表現できるため)
+            id |= motor << (can_id_size - motor_prefix_size - motor_count_prefix_size - 1);
+
+            // DIPスイッチの値をそのままIDに反映する
+            id |= dip_switch << (can_id_size - motor_prefix_size - motor_count_prefix_size - 1 - dip_switch_size);
+
+            return id;
+        case 2:
+            // 基板のモータは4つであることを示す
+            id |= 0x02 << (can_id_size - motor_prefix_size - motor_count_prefix_size);
+
+            // どちらのモーターかを示す(シフトの2はmotorの値が0-3であり、どのmotorかを2bitで表現できるため)
+            id |= motor << (can_id_size - motor_prefix_size - motor_count_prefix_size - 2);
+
+            // DIPスイッチの値をそのままIDに反映する
+            id |= dip_switch << (can_id_size - motor_prefix_size - motor_count_prefix_size - 2 - dip_switch_size);
+
+            return id;
+        default:
+            // 8個のモーターは未対応
+            // 将来の拡張を考えて、0b11を残している
+            // 例えば0b1100の場合8、0b1101の場合16をモーターに割り当てるなどする
+            return 0;
+    }
+}
+
+}  // namespace can
+
+}  // namespace spirit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,8 +34,9 @@ endfunction()
 include(GoogleTest)
 
 # CTestへ単体テストを登録
-add_gtest(test_Motor.cpp)
-add_gtest(test_CANMessage.cpp)
-add_gtest(test_PwmDataConverter.cpp)
-add_gtest(test_MdLed.cpp)
 add_gtest(test_A3921.cpp)
+add_gtest(test_CANMessage.cpp)
+add_gtest(test_Id.cpp)
+add_gtest(test_MdLed.cpp)
+add_gtest(test_Motor.cpp)
+add_gtest(test_PwmDataConverter.cpp)

--- a/tests/test_Id.cpp
+++ b/tests/test_Id.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include "Id.h"
+
+using namespace spirit;
+
+TEST(Id, IdCanMotorTest)
+{
+    // 正常系のテスト
+    // モーターの数が1の場合
+    // dip_switchに着目
+    EXPECT_EQ(0x200, can::get_motor_id(1, 0, 0x0));
+    EXPECT_EQ(0x27C, can::get_motor_id(1, 0, 0x1F));
+
+    // モーターの数が2の場合
+    // motorに着目
+    EXPECT_EQ(0x2BE, can::get_motor_id(2, 0, 0x1F));
+    EXPECT_EQ(0x2FE, can::get_motor_id(2, 1, 0x1F));
+    // dip_switchに着目(0xFは既にやっているので除外)
+    EXPECT_EQ(0x280, can::get_motor_id(2, 0, 0x0));
+
+    // モーターの数が3/4の場合
+    // motorに着目
+    EXPECT_EQ(0x31F, can::get_motor_id(3, 0, 0x1F));
+    EXPECT_EQ(0x35F, can::get_motor_id(3, 2, 0x1F));
+    EXPECT_EQ(0x31F, can::get_motor_id(4, 0, 0x1F));
+    EXPECT_EQ(0x37F, can::get_motor_id(4, 3, 0x1F));
+    // dip_switchに着目(0xFは既にやっているので除外)
+    EXPECT_EQ(0x300, can::get_motor_id(3, 0, 0x00));
+    EXPECT_EQ(0x300, can::get_motor_id(4, 0, 0x00));
+
+    // 異常系のテスト
+    // dip_switchの値がビット幅( dip_switch_size )を超えている場合
+    EXPECT_EQ(0, can::get_motor_id(1, 0, 0x20));
+
+    // motorの値がモーターの数を超えている場合
+    EXPECT_EQ(0, can::get_motor_id(1, 1, 0x0));
+    EXPECT_EQ(0, can::get_motor_id(2, 2, 0x0));
+    EXPECT_EQ(0, can::get_motor_id(3, 3, 0x0));
+    EXPECT_EQ(0, can::get_motor_id(4, 4, 0x0));
+
+    // 非対応の個数のモーターの場合
+    EXPECT_EQ(0, can::get_motor_id(0, 0, 0x0));
+    EXPECT_EQ(0, can::get_motor_id(5, 0, 0x0));
+    EXPECT_EQ(0, can::get_motor_id(8, 0, 0x0));
+}


### PR DESCRIPTION
**Issue**

- #91

**対応内容**

CAN通信の場合のIDを返す関数を追加した

**テスト**

`can::get_motor_id` の各引数に着目したテストを追加

**残作業**

SPI, I2Cの場合の取り決め
