### PR TITLE
update: トランスポート層相当のレイヤーを追加する(UDP)

### DIFF
--- a/include/FakeUdpConverter.h
+++ b/include/FakeUdpConverter.h
@@ -1,0 +1,39 @@
+#ifndef SPIRIT_FAKE_UDP_CONVERTER_H
+#define SPIRIT_FAKE_UDP_CONVERTER_H
+
+#include <cstdint>
+
+namespace spirit {
+
+class FakeUdpConverter {
+public:
+    /**
+     * @brief FakeUdpをエンコードする
+     * @param payload ペイロード
+     * @param payload_size ペイロードのビット幅
+     * @param max_buffer_size エンコードしたデータの最大ビット幅
+     * @param buffer エンコードしたデータを格納するバッファ
+     * @param buffer_size エンコードしたデータのビット幅
+     * @return
+     */
+    bool encode(const uint8_t* payload, std::size_t payload_size, const std::size_t max_buffer_size, uint8_t* buffer,
+                std::size_t& buffer_size);
+
+    /**
+     * @brief FakeUdpをデコードする
+     * @param buffer デコードするデータ
+     * @param buffer_size デコードするデータのビット幅
+     * @param max_payload_size デコードしたペイロードの最大ビット幅
+     * @param payload デコードしたペイロードを格納するバッファ
+     * @param payload_size デコードしたペイロードのビット幅
+     * @return
+     */
+    bool decode(const uint8_t* buffer, std::size_t buffer_size, std::size_t max_payload_size, uint8_t* payload,
+                std::size_t& payload_size);
+
+private:
+};
+
+}  // namespace spirit
+
+#endif  // SPIRIT_FAKE_UDP_CONVERTER_H

--- a/include/PwmDataConverter.h
+++ b/include/PwmDataConverter.h
@@ -15,9 +15,9 @@ public:
     /**
      * @brief モーターの情報をエンコードする
      * @param motor モーター
-     * @param max_buffer_size エンコードしたデータの最大サイズ
+     * @param max_buffer_size エンコードしたデータの最大ビット幅
      * @param buffer エンコードしたデータを格納するバッファ
-     * @param buffer_size エンコードしたデータのサイズ
+     * @param buffer_size エンコードしたデータのビット幅
      * @return
      */
     bool encode(const Motor& motor, std::size_t max_buffer_size, uint8_t* buffer, std::size_t& buffer_size);
@@ -25,7 +25,7 @@ public:
     /**
      * @brief モーターの情報をデコードする
      * @param buffer デコードするデータ
-     * @param buffer_size デコードするデータのサイズ
+     * @param buffer_size デコードするデータのビット幅
      * @param motor デコードした情報を格納するモーター
      * @return
      */

--- a/source/FakeUdpConverter.cpp
+++ b/source/FakeUdpConverter.cpp
@@ -1,0 +1,65 @@
+#include "FakeUdpConverter.h"
+
+namespace spirit {
+
+bool FakeUdpConverter::encode(const uint8_t* payload, const std::size_t payload_size, const std::size_t max_buffer_size,
+                              uint8_t* buffer, std::size_t& buffer_size)
+{
+    // コネクションなどは初版のリリースには入れないため、現在はトランスポート層に相当するFakeUpdやFakeTcp(未実装)は、何も制御/処理をしない
+    // 将来処理をさせるときのために、とりあえずヘッダとして1bit(0b0)だけデータに挿入する
+
+    if (payload_size == 0) {
+        return false;
+    }
+
+    buffer_size = payload_size + 1;
+    if (buffer_size > max_buffer_size) {
+        return false;
+    }
+
+    std::size_t payload_byte_size = payload_size / 8;
+    if (payload_size % 8 != 0) {
+        payload_byte_size++;
+    }
+
+    buffer[0] = payload[0] >> 1;
+    for (std::size_t i = 1; i < payload_byte_size; i++) {
+        buffer[i] = ((payload[i - 1] & 1) << 7) + (payload[i] >> 1);
+    }
+
+    if (payload_size % 8 == 0) {
+        buffer[payload_byte_size] = (payload[payload_byte_size - 1] & 1) << 7;
+    }
+
+    return true;
+}
+
+bool FakeUdpConverter::decode(const uint8_t* buffer, const std::size_t buffer_size, const std::size_t max_payload_size,
+                              uint8_t* payload, std::size_t& payload_size)
+{
+    if (buffer_size == 0) {
+        return false;
+    }
+
+    // ペイロードはbuffer_sizeよりも1小さくなるので、
+    // 最大ペイロードサイズがbuffer_size - 1よりも大きい場合は、デコードできない
+    if (max_payload_size < buffer_size - 1) {
+        return false;
+    }
+
+    std::size_t buffer_byte_size = buffer_size / 8;
+    if (buffer_size % 8 != 0) {
+        buffer_byte_size++;
+    }
+
+    for (std::size_t i = 0; i < buffer_byte_size - 1; i++) {
+        payload[i] = ((buffer[i] & 0x7F) << 1) + (buffer[i + 1] >> 7);
+    }
+    payload[buffer_byte_size - 1] = ((buffer[buffer_byte_size - 1] & 0x7F) << 1);
+
+    payload_size = buffer_size - 1;
+
+    return true;
+}
+
+}  // namespace spirit

--- a/source/PwmDataConverter.cpp
+++ b/source/PwmDataConverter.cpp
@@ -9,14 +9,15 @@ namespace spirit {
 bool PwmDataConverter::encode(const Motor& motor, const std::size_t max_buffer_size, uint8_t* buffer,
                               std::size_t& buffer_size)
 {
-    // PWM制御を示すヘッダをセット(既に0で初期化されているので不要)
-    // buffer[0] = 0x00;
-
-    buffer_size = 3;
+    // 2(ヘッダ) + 16(デューティー比) + 2(回転方向) = 20
+    buffer_size = 20;
 
     if (max_buffer_size < buffer_size) {
         return false;
     }
+
+    // PWM制御を示すヘッダをセット
+    buffer[0] = 0x00;
 
     set_duty_cycle(motor.get_duty_cycle(), buffer);
 
@@ -27,7 +28,8 @@ bool PwmDataConverter::encode(const Motor& motor, const std::size_t max_buffer_s
 
 bool PwmDataConverter::decode(const uint8_t* buffer, std::size_t buffer_size, Motor& motor)
 {
-    const std::size_t required_size = 3;
+    // 2(ヘッダ) + 16(デューティー比) + 2(回転方向) = 20
+    constexpr std::size_t required_size = 20;
     if (buffer_size < required_size) {
         return false;
     }

--- a/tests/test_FakeUdpConverter.cpp
+++ b/tests/test_FakeUdpConverter.cpp
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+
+#include "FakeUdpConverter.h"
+
+using namespace spirit;
+
+/**
+ * @brief エンコード処理のテスト
+ */
+TEST(FakeUdpConverter, EncodeTest)
+{
+    //
+    // 正常系
+    //
+
+    // payloadが1byteの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t payload_size = 8;
+        uint8_t               payload[1]   = {0xFF};
+
+        constexpr std::size_t max_buffer_size = 64;
+        uint8_t               buffer[8]       = {};
+
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, payload_size, max_buffer_size, buffer, buffer_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(buffer[0], 0x7F);
+        EXPECT_EQ(buffer[1], 0x80);
+        EXPECT_EQ(buffer_size, payload_size + 1);
+    }
+
+    // payloadが2byteの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t payload_size = 16;
+        uint8_t               payload[2]   = {0xFF, 0xFF};
+
+        constexpr std::size_t max_buffer_size = 64;
+        uint8_t               buffer[8]       = {};
+
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, payload_size, max_buffer_size, buffer, buffer_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(buffer[0], 0x7F);
+        EXPECT_EQ(buffer[1], 0xFF);
+        EXPECT_EQ(buffer[2], 0x80);
+        EXPECT_EQ(buffer_size, payload_size + 1);
+    }
+
+    // payloadが7bitの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t payload_size = 7;
+        uint8_t               payload[1]   = {0xFE};
+
+        constexpr std::size_t max_buffer_size = 64;
+        uint8_t               buffer[8]       = {};
+
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, payload_size, max_buffer_size, buffer, buffer_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(buffer[0], 0x7F);
+        EXPECT_EQ(buffer_size, payload_size + 1);
+    }
+
+    //
+    // 異常系
+    //
+
+    // payload_size == 0
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        uint8_t     payload[1]  = {};
+        uint8_t     buffer[8]   = {};
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, 0, 1, buffer, buffer_size);
+
+        EXPECT_FALSE(result);
+    }
+
+    // payload_size > max_buffer_size
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        uint8_t     payload[1]  = {};
+        uint8_t     buffer[8]   = {};
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, 2, 1, buffer, buffer_size);
+
+        EXPECT_FALSE(result);
+    }
+
+    // payload_size == max_buffer_size
+    // FakeUdpのデータを挿入するためサイズがpayload_sizeよりも1大きくなるため、
+    // payload_size == max_buffer_size だとエラーにする必要がある
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        uint8_t     payload[1]  = {};
+        uint8_t     buffer[8]   = {};
+        std::size_t buffer_size = 0;
+
+        bool result = fake_udp_converter.encode(payload, 1, 1, buffer, buffer_size);
+
+        EXPECT_FALSE(result);
+    }
+}
+
+/**
+ * @brief エンコード処理のテスト
+ */
+TEST(FakeUdpConverter, DecodeTest)
+{
+    //
+    // 正常系
+    //
+
+    // bufferが1byteの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t max_payload_size = 8;
+        std::size_t           payload_size;
+        uint8_t               payload[1] = {};
+
+        uint8_t               buffer[1]   = {0x7F};
+        constexpr std::size_t buffer_size = 8;
+
+        bool result = fake_udp_converter.decode(buffer, buffer_size, max_payload_size, payload, payload_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(payload[0], 0xFE);
+        EXPECT_EQ(payload_size, 7);
+    }
+
+    // bufferが2byteの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t max_payload_size = 16;
+        std::size_t           payload_size;
+        uint8_t               payload[2] = {};
+
+        uint8_t               buffer[2]   = {0x7F, 0xFF};
+        constexpr std::size_t buffer_size = 16;
+
+        bool result = fake_udp_converter.decode(buffer, buffer_size, max_payload_size, payload, payload_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(payload[0], 0xFF);
+        EXPECT_EQ(payload[1], 0xFE);
+        EXPECT_EQ(payload_size, 15);
+    }
+
+    // bufferが7bitの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t max_payload_size = 16;
+        std::size_t           payload_size;
+        uint8_t               payload[2] = {};
+
+        uint8_t               buffer[1]   = {0x7E};
+        constexpr std::size_t buffer_size = 7;
+
+        bool result = fake_udp_converter.decode(buffer, buffer_size, max_payload_size, payload, payload_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(payload[0], 0xFC);
+        EXPECT_EQ(payload_size, 6);
+    }
+
+    // bufferが9bitの場合
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        constexpr std::size_t max_payload_size = 16;
+        std::size_t           payload_size;
+        uint8_t               payload[1] = {};
+
+        uint8_t               buffer[2]   = {0x7F, 0x80};
+        constexpr std::size_t buffer_size = 9;
+
+        bool result = fake_udp_converter.decode(buffer, buffer_size, max_payload_size, payload, payload_size);
+
+        EXPECT_TRUE(result);
+        EXPECT_EQ(payload[0], 0xFF);
+        EXPECT_EQ(payload_size, 8);
+    }
+
+    //
+    // 異常系
+    //
+
+    // buffer_size - 1 < max_payload_size
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        std::size_t payload_size;
+        uint8_t     payload[1] = {};
+
+        uint8_t buffer[1] = {};
+
+        bool result = fake_udp_converter.decode(buffer, 3, 1, payload, payload_size);
+
+        EXPECT_FALSE(result);
+    }
+
+    // buffer_size = 0
+    {
+        FakeUdpConverter fake_udp_converter;
+
+        std::size_t payload_size;
+        uint8_t     payload[1] = {};
+
+        uint8_t buffer[1] = {};
+
+        bool result = fake_udp_converter.decode(buffer, 0, 8, payload, payload_size);
+
+        EXPECT_FALSE(result);
+    }
+}

--- a/tests/test_PwmDataConverter.cpp
+++ b/tests/test_PwmDataConverter.cpp
@@ -16,12 +16,15 @@ TEST(PwmDataConverter, EncodeDecodePwmTest)
         motor.duty_cycle(duty_cycle);
         motor.state(state);
 
-        constexpr std::size_t max_buffer_size = 8;
-        uint8_t               buffer[max_buffer_size]{};
+        constexpr std::size_t max_buffer_size = 24;
+        uint8_t               buffer[max_buffer_size / 8]{};
         std::size_t           buffer_size = 0;
 
         pwm_data_converter.encode(motor, max_buffer_size, buffer, buffer_size);
-        EXPECT_EQ(3, buffer_size);
+
+        // 2(ヘッダ) + 16(デューティー比) + 2(回転方向) = 20
+        constexpr std::size_t expected_buffer_size = 20;
+        EXPECT_EQ(expected_buffer_size, buffer_size);
 
         Motor decoded_motor;
         pwm_data_converter.decode(buffer, max_buffer_size, decoded_motor);
@@ -75,9 +78,9 @@ TEST(PwmDataConverter, MaxBufferSizeTest)
 
     // バッファサイズが0、境界値の場合のテストを行う
     max_buffer_size_test(0, false);
-    max_buffer_size_test(2, false);
-    max_buffer_size_test(3, true);
-    max_buffer_size_test(4, true);
+    max_buffer_size_test(16, false);
+    max_buffer_size_test(24, true);
+    max_buffer_size_test(32, true);
 }
 
 /**
@@ -100,7 +103,7 @@ TEST(PwmDataConverter, EncodeBufferSizeTest)
 
     // バッファサイズが0、境界値の場合のテストを行う
     buffer_size_test(0, false);
-    buffer_size_test(2, false);
-    buffer_size_test(3, true);
-    buffer_size_test(4, true);
+    buffer_size_test(6, false);
+    buffer_size_test(24, true);
+    buffer_size_test(32, true);
 }


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #113

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
タイトルの通り

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
- 「ビット幅の節約のために、既存のバッファの幅の精度をbyteからbitにする」に伴ってPwmDataConverterのテストを修正
- FakeUdpのテスト用を新規作成


## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
