### PR TITLE
fix: 他のプロジェクトがmbedのライブラリとして利用した時にビルドエラーとなる問題を修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,43 @@ target_include_directories(spirit
 
 target_sources(spirit
     PUBLIC
-    source/A3921.cpp
-    source/bit.cpp
-    source/CANMessage.cpp
-    source/FakeUdpConverter.cpp
-    source/Id.cpp
-    source/MdLed.cpp
-    source/Motor.cpp
-    source/PwmDataConverter.cpp
+    ./source/A3921.cpp
+    ./source/bit.cpp
+    ./source/CANMessage.cpp
+    ./source/FakeUdpConverter.cpp
+    ./source/Id.cpp
+    ./source/MdLed.cpp
+    ./source/Motor.cpp
+    ./source/PwmDataConverter.cpp
 )
 
 enable_testing()
 
-add_subdirectory(tests)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    add_subdirectory(tests)
+endif()
+
+if(DEFINED MBED_PATH)
+    add_library(spirit-platform-mbed STATIC)
+
+    if(MSVC)
+        target_compile_options(spirit-platform-mbed PUBLIC /W4)
+    else()
+        target_compile_options(spirit-platform-mbed PUBLIC -O2 -Wall -Wextra)
+    endif()
+
+    target_include_directories(spirit-platform-mbed
+        PUBLIC
+        .
+        ./include
+        ./platform/mbed/include
+    )
+
+    target_sources(spirit-platform-mbed
+        PUBLIC
+        ./platform/mbed/source/DigitalOut.cpp
+        ./platform/mbed/source/PwmOut.cpp
+    )
+
+    target_link_libraries(spirit-platform-mbed spirit mbed-os)
+endif()


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
https://github.com/yutotnh/mbed-can-motor-driver-for-spirit で本ライブラリをビルドしたらエラーになった

そのエラーを回避するための修正が入っている

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
本修正はほかのプロジェクトからビルドされたときにはじめて意味が分かる

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
- #112