### PR TITLE
fix: std::string を使わないように変更

### DIFF
--- a/include/Error.h
+++ b/include/Error.h
@@ -2,7 +2,7 @@
 #define SPIRIT_ERROR_H
 
 #include <cstdint>
-#include <string>
+#include <cstdio>
 
 #include "include/mutex.h"
 

--- a/include/Error.h
+++ b/include/Error.h
@@ -85,8 +85,8 @@ public:
     void error(Type type, uint32_t code, const char* message, const char* filename, const char* funcname,
                uint32_t line_number);
 
-    static constexpr uint32_t max_uint32_t_length       = 10;
-    static constexpr uint32_t max_float_exponent_length = 10;
+    static constexpr uint32_t max_uint32_t_length    = 10;
+    static constexpr uint32_t max_float_1_4_e_length = 10;
 
 private:
     Error()  = default;

--- a/include/Error.h
+++ b/include/Error.h
@@ -85,6 +85,9 @@ public:
     void error(Type type, uint32_t code, const char* message, const char* filename, const char* funcname,
                uint32_t line_number);
 
+    static constexpr uint32_t max_uint32_t_length       = 10;
+    static constexpr uint32_t max_float_exponent_length = 10;
+
 private:
     Error()  = default;
     ~Error() = default;

--- a/source/A3921.cpp
+++ b/source/A3921.cpp
@@ -45,9 +45,11 @@ void A3921::state(const Motor::State type)
         case Motor::State::Brake:
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -61,15 +63,15 @@ void A3921::decay(const Motor::Decay type)
         case Motor::Decay::Slow:
         case Motor::Decay::Fast:
             break;
-
-        // 非対応
         case Motor::Decay::Mixed:
             error.error(Error::Type::InvalidValue, 0, "Invalid motor decay (Motor::Decay::Mixed)", __FILE__, __func__,
                         __LINE__);
             return;
         default:
-            const std::string message = "Unknown motor decay (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            constexpr char message_base[] = "Unknown motor decay (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -83,9 +85,11 @@ void A3921::pwm_side(const Motor::PwmSide type)
         case Motor::PwmSide::High:
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor pwm side (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor pwm side (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -109,8 +113,10 @@ void A3921::run()
                         __LINE__);
             return;
         default:
-            const std::string message = "Unknown motor decay (" + std::to_string(static_cast<uint32_t>(_decay)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            constexpr char message_base[] = "Unknown motor decay (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_decay));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 }
@@ -130,10 +136,11 @@ void A3921::run_slow_decay()
             pwm_high_side = _duty_cycle;
             break;
         default:
-            Error&            error = Error::get_instance();
-            const std::string message =
-                "Unknown motor pwm side (" + std::to_string(static_cast<uint32_t>(_pwm_side)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor pwm side (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_pwm_side));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -169,9 +176,11 @@ void A3921::run_slow_decay()
             break;
 
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(_state)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_state));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 }
@@ -210,9 +219,11 @@ void A3921::run_fast_decay()
             break;
 
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(_state)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_state));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 }
@@ -224,9 +235,11 @@ void A3921::pulse_period(const float seconds)
         _pwml.period(seconds);
         _phase.period(seconds);
     } else {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Invalid motor pulse period (" + std::to_string(seconds) + ")";
-        error.error(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Invalid motor pulse period (%1.4e)";
+        char           message[sizeof(message_base) + Error::max_float_1_4_e_length];
+        snprintf(message, sizeof(message), message_base, seconds);
+        error.error(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     }
 }
 

--- a/source/Error.cpp
+++ b/source/Error.cpp
@@ -3,7 +3,7 @@
 #ifdef __MBED__
 #include "mbed.h"
 #else
-#include <iostream>
+#include <cstdio>
 #endif
 
 namespace spirit {

--- a/source/Error.cpp
+++ b/source/Error.cpp
@@ -54,9 +54,11 @@ void Error::print(Type type, uint32_t code, const char* message, const char* fil
             sprintf((char*)status_string, "Error");
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown error status (" + std::to_string(static_cast<uint32_t>(_status)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown error status (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_status));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
     }
 
@@ -75,9 +77,11 @@ void Error::print(Type type, uint32_t code, const char* message, const char* fil
             sprintf((char*)type_string, "InvalidValue");
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown error type (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown error type (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
     }
 

--- a/source/FakeUdpConverter.cpp
+++ b/source/FakeUdpConverter.cpp
@@ -18,11 +18,11 @@ bool FakeUdpConverter::encode(const uint8_t* payload, const std::size_t payload_
 
     buffer_size = payload_size + 1;
     if (max_buffer_size < buffer_size) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Buffer size (" + std::to_string(buffer_size) +
-                                    ") is larger than the maximum buffer size (" + std::to_string(max_buffer_size) +
-                                    ")";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Buffer size (%d) is larger than the maximum buffer size (%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
+        snprintf(message, sizeof(message), message_base, buffer_size, max_buffer_size);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
         return false;
     }
 
@@ -55,11 +55,11 @@ bool FakeUdpConverter::decode(const uint8_t* buffer, const std::size_t buffer_si
     // ペイロードはbuffer_sizeよりも1小さくなるので、
     // 最大ペイロードサイズがbuffer_size - 1よりも大きい場合は、デコードできない
     if (max_payload_size < buffer_size - 1) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Payload size (" + std::to_string(buffer_size - 1) +
-                                    ") is larger than the maximum payload size (" + std::to_string(max_payload_size) +
-                                    ")";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Payload size (%d) is larger than the maximum payload size (%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
+        snprintf(message, sizeof(message), message_base, buffer_size - 1, max_payload_size);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
         return false;
     }
 

--- a/source/FakeUdpConverter.cpp
+++ b/source/FakeUdpConverter.cpp
@@ -19,7 +19,7 @@ bool FakeUdpConverter::encode(const uint8_t* payload, const std::size_t payload_
     buffer_size = payload_size + 1;
     if (max_buffer_size < buffer_size) {
         Error&         error          = Error::get_instance();
-        constexpr char message_base[] = "Buffer size (%d) is larger than the maximum buffer size (%d)";
+        constexpr char message_base[] = "Buffer size (%zu) is larger than the maximum buffer size (%zu)";
         char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
         snprintf(message, sizeof(message), message_base, buffer_size, max_buffer_size);
         error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
@@ -56,7 +56,7 @@ bool FakeUdpConverter::decode(const uint8_t* buffer, const std::size_t buffer_si
     // 最大ペイロードサイズがbuffer_size - 1よりも大きい場合は、デコードできない
     if (max_payload_size < buffer_size - 1) {
         Error&         error          = Error::get_instance();
-        constexpr char message_base[] = "Payload size (%d) is larger than the maximum payload size (%d)";
+        constexpr char message_base[] = "Payload size (%zu) is larger than the maximum payload size (%zu)";
         char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
         snprintf(message, sizeof(message), message_base, buffer_size - 1, max_payload_size);
         error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);

--- a/source/Id.cpp
+++ b/source/Id.cpp
@@ -52,18 +52,20 @@ uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const ui
     }
 
     if (motor_is_valid(motor, motor_count) == false) {
-        Error&            error = Error::get_instance();
-        const std::string message =
-            "Motor number (" + std::to_string(motor) + ") is out of range (0-" + std::to_string(motor_count - 1) + ")";
-        error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Motor number (%d) is out of range (0-%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
+        sprintf(message, message_base, motor, motor_count - 1);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
         return 0;
     }
 
     if (dip_switch_is_valid(dip_switch, dip_switch_size) == false) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Dip switch value (" + std::to_string(dip_switch) +
-                                    ") exceeds maximum bit width (" + std::to_string(dip_switch_size) + ")";
-        error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "DIP switch value (%d) exceeds maximum bit width (%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 2];
+        sprintf(message, message_base, dip_switch, dip_switch_size);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
         return 0;
     }
 
@@ -75,9 +77,11 @@ uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const ui
     uint32_t type = 0;
 
     if ((motor_count == 0) || (4 < motor_count)) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Unknown motor count type (" + std::to_string(motor_count) + ")";
-        error.warning(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Unknown motor count type (%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length];
+        sprintf(message, message_base, motor_count);
+        error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
         return 0;
     }
 
@@ -88,8 +92,11 @@ uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const ui
     } else if (motor_count <= 4) {
         type = 2;
     } else {
-        Error& error = Error::get_instance();
-        error.warning(Error::Type::UnknownValue, 0, "Unkown motor count type", __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Unknown motor count type (%d)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length];
+        sprintf(message, message_base, motor_count);
+        error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
         return 0;
     }
 
@@ -128,8 +135,11 @@ uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const ui
             // 8個のモーターは未対応
             // 将来の拡張を考えて、0b11を残している
             // 例えば0b1100の場合8、0b1101の場合16をモーターに割り当てるなどする
-            Error& error = Error::get_instance();
-            error.warning(Error::Type::UnknownValue, 0, "Unkown motor count type", __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor count type (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            sprintf(message, message_base, motor_count);
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return 0;
     }
 }

--- a/source/Id.cpp
+++ b/source/Id.cpp
@@ -45,9 +45,8 @@ uint32_t get_motor_id(const uint32_t motor_count, const uint32_t motor, const ui
     constexpr uint32_t motor_count_prefix_size = 2;
 
     if (motor_count == 0) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Total number of motors is 0";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error& error = Error::get_instance();
+        error.warning(Error::Type::InvalidValue, 0, "Total number of motors is 0", __FILE__, __func__, __LINE__);
         return 0;
     }
 

--- a/source/MdLed.cpp
+++ b/source/MdLed.cpp
@@ -36,9 +36,9 @@ void MdLed::state(const Motor::State type)
             break;
         default:
             // 未定義の値
-            Error &error          = Error::get_instance();
-            char   message_base[] = "Unknown motor state (%d)";
-            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            Error         &error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
             snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
             error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
@@ -69,9 +69,9 @@ void MdLed::mode(const BlinkMode mode)
         case BlinkMode::Error:
             break;
         default:
-            Error &error          = Error::get_instance();
-            char   message_base[] = "Unknown blink mode (%d)";
-            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            Error         &error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown blink mode (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
             snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(mode));
             error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
@@ -88,9 +88,9 @@ void MdLed::mode(const BlinkMode mode)
             concurrently_blink();
             break;
         default:
-            Error &error          = Error::get_instance();
-            char   message_base[] = "Unknown blink mode (%d)";
-            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            Error         &error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown blink mode (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
             snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(mode));
             error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
@@ -124,9 +124,9 @@ void MdLed::coordinate()
                 error_blink();
                 break;
             default:
-                Error &error          = Error::get_instance();
-                char   message_base[] = "Unknown blink mode (%d)";
-                char   message[sizeof(message_base) + Error::max_uint32_t_length];
+                Error         &error          = Error::get_instance();
+                constexpr char message_base[] = "Unknown blink mode (%d)";
+                char           message[sizeof(message_base) + Error::max_uint32_t_length];
                 snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_mode));
                 error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
                 return;

--- a/source/MdLed.cpp
+++ b/source/MdLed.cpp
@@ -36,9 +36,11 @@ void MdLed::state(const Motor::State type)
             break;
         default:
             // 未定義の値
-            Error            &error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error &error          = Error::get_instance();
+            char   message_base[] = "Unknown motor state (%d)";
+            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
     }
 }
@@ -67,9 +69,11 @@ void MdLed::mode(const BlinkMode mode)
         case BlinkMode::Error:
             break;
         default:
-            Error            &error   = Error::get_instance();
-            const std::string message = "Unknown blink mode (" + std::to_string(static_cast<uint32_t>(mode)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error &error          = Error::get_instance();
+            char   message_base[] = "Unknown blink mode (%d)";
+            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(mode));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -84,9 +88,11 @@ void MdLed::mode(const BlinkMode mode)
             concurrently_blink();
             break;
         default:
-            Error            &error   = Error::get_instance();
-            const std::string message = "Unknown blink mode (" + std::to_string(static_cast<uint32_t>(mode)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error &error          = Error::get_instance();
+            char   message_base[] = "Unknown blink mode (%d)";
+            char   message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(mode));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 }
@@ -118,9 +124,11 @@ void MdLed::coordinate()
                 error_blink();
                 break;
             default:
-                Error            &error   = Error::get_instance();
-                const std::string message = "Unknown blink mode (" + std::to_string(static_cast<uint32_t>(_mode)) + ")";
-                error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+                Error &error          = Error::get_instance();
+                char   message_base[] = "Unknown blink mode (%d)";
+                char   message[sizeof(message_base) + Error::max_uint32_t_length];
+                snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(_mode));
+                error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
                 return;
         }
     }

--- a/source/Motor.cpp
+++ b/source/Motor.cpp
@@ -11,9 +11,11 @@ void Motor::control_system(const ControlSystem type)
         case ControlSystem::Speed:
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unkown motor type (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor control system (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -30,16 +32,19 @@ void Motor::duty_cycle(const float value)
     if (1.00F < value) {
         _duty_cycle = 1.00F;
 
-        Error&            error = Error::get_instance();
-        const std::string message =
-            "Duty cycle (" + std::to_string(value) + ") is greater than 1.00, so it will be 1.00";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Duty cycle (%1.4e) is greater than 1.00, so it will be 1.00";
+        char           message[sizeof(message_base) + Error::max_float_1_4_e_length];
+        snprintf(message, sizeof(message), message_base, value);
+        error.warning(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     } else if (value < 0.00F) {
         _duty_cycle = 0.00F;
 
-        Error&            error   = Error::get_instance();
-        const std::string message = "Duty cycle (" + std::to_string(value) + ") is less than 0.00, so it will be 0.00";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Duty cycle (%1.4e) is less than 0.00, so it will be 0.00";
+        char           message[sizeof(message_base) + Error::max_float_1_4_e_length];
+        snprintf(message, sizeof(message), message_base, value);
+        error.warning(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     } else {
         _duty_cycle = value;
     }
@@ -83,9 +88,11 @@ void Motor::state(const State type)
         case State::Brake:
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unkown motor state (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -107,10 +114,14 @@ void Motor::change_level(const ChangeLevelTarget target, const ChangeLevel level
         case ChangeLevel::Max:
             break;
         default:
-            Error&            error = Error::get_instance();
-            const std::string message =
-                "Unkown motor change level (" + std::to_string(static_cast<uint32_t>(level)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor change level (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(level));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
+            // const std::string message =
+            //     "Unkown motor change level (" + std::to_string(static_cast<uint32_t>(level)) + ")";
+            // error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -122,10 +133,14 @@ void Motor::change_level(const ChangeLevelTarget target, const ChangeLevel level
             _fall_change_level = level;
             break;
         default:
-            Error&            error = Error::get_instance();
-            const std::string message =
-                "Unkown motor change level target (" + std::to_string(static_cast<uint32_t>(target)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor change level target (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(target));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
+            // const std::string message =
+            //     "Unkown motor change level target (" + std::to_string(static_cast<uint32_t>(target)) + ")";
+            // error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
             return;
     }
 }
@@ -138,10 +153,11 @@ Motor::ChangeLevel Motor::get_change_level(const ChangeLevelTarget target) const
         case ChangeLevelTarget::Fall:
             return _fall_change_level;
         default:
-            Error&            error = Error::get_instance();
-            const std::string message =
-                "Unkown motor change level target (" + std::to_string(static_cast<uint32_t>(target)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor change level target (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(target));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return ChangeLevel::OFF;
     }
 }
@@ -151,19 +167,21 @@ void Motor::pulse_period(const float seconds)
     if (max_pulse_period < seconds) {
         _pulse_period = max_pulse_period;
 
-        Error&            error   = Error::get_instance();
-        const std::string message = "Pulse period (" + std::to_string(seconds) +
-                                    ") is greater than max pulse period (" + std::to_string(max_pulse_period) +
-                                    "), so it will be max pulse period (" + std::to_string(max_pulse_period) + ")";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error = Error::get_instance();
+        constexpr char message_base[] =
+            "Pulse period (%1.4e) is greater than max pulse period (%1.4e), so it will be max pulse period (%1.4e)";
+        char message[sizeof(message_base) + Error::max_float_length * 3];
+        snprintf(message, sizeof(message), message_base, seconds, max_pulse_period, max_pulse_period);
+        error.warning(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     } else if (seconds < min_pulse_period) {
         _pulse_period = min_pulse_period;
 
-        Error&            error   = Error::get_instance();
-        const std::string message = "Pulse period (" + std::to_string(seconds) + ") is less than min pulse period (" +
-                                    std::to_string(min_pulse_period) + "), so it will be min pulse period (" +
-                                    std::to_string(min_pulse_period) + ")";
-        error.warning(Error::Type::InvalidValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error = Error::get_instance();
+        constexpr char message_base[] =
+            "Pulse period (%1.4e) is less than min pulse period (%1.4e), so it will be min pulse period (%1.4e)";
+        char message[sizeof(message_base) + Error::max_float_1_4_e_length * 3];
+        snprintf(message, sizeof(message), message_base, seconds, min_pulse_period, min_pulse_period);
+        error.warning(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     } else {
         _pulse_period = seconds;
     }
@@ -196,8 +214,10 @@ void Motor::decay(const Decay type)
                         __LINE__);
             return;
         default:
-            const std::string message = "Unkown motor decay (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            constexpr char message_base[] = "Unknown motor decay (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -216,9 +236,11 @@ void Motor::pwm_side(const PwmSide type)
         case PwmSide::High:
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unkown motor PWM side (" + std::to_string(static_cast<uint32_t>(type)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor PWM side (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(type));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return;
     }
 

--- a/source/Motor.cpp
+++ b/source/Motor.cpp
@@ -119,9 +119,6 @@ void Motor::change_level(const ChangeLevelTarget target, const ChangeLevel level
             char           message[sizeof(message_base) + Error::max_uint32_t_length];
             snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(level));
             error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
-            // const std::string message =
-            //     "Unkown motor change level (" + std::to_string(static_cast<uint32_t>(level)) + ")";
-            // error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
             return;
     }
 
@@ -138,9 +135,6 @@ void Motor::change_level(const ChangeLevelTarget target, const ChangeLevel level
             char           message[sizeof(message_base) + Error::max_uint32_t_length];
             snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(target));
             error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
-            // const std::string message =
-            //     "Unkown motor change level target (" + std::to_string(static_cast<uint32_t>(target)) + ")";
-            // error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
             return;
     }
 }

--- a/source/Motor.cpp
+++ b/source/Motor.cpp
@@ -170,7 +170,7 @@ void Motor::pulse_period(const float seconds)
         Error&         error = Error::get_instance();
         constexpr char message_base[] =
             "Pulse period (%1.4e) is greater than max pulse period (%1.4e), so it will be max pulse period (%1.4e)";
-        char message[sizeof(message_base) + Error::max_float_length * 3];
+        char message[sizeof(message_base) + Error::max_float_1_4_e_length * 3];
         snprintf(message, sizeof(message), message_base, seconds, max_pulse_period, max_pulse_period);
         error.warning(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
     } else if (seconds < min_pulse_period) {

--- a/source/PwmDataConverter.cpp
+++ b/source/PwmDataConverter.cpp
@@ -1,7 +1,5 @@
 #include "PwmDataConverter.h"
 
-#include <cstring>
-
 #include "bit.h"
 #include "include/Error.h"
 

--- a/source/PwmDataConverter.cpp
+++ b/source/PwmDataConverter.cpp
@@ -67,9 +67,11 @@ Motor::State PwmDataConverter::get_state(const uint8_t* buffer)
         case 0x03U:
             return Motor::State::Brake;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(state_uint32_t) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            std::snprintf(message, sizeof(message), message_base, state_uint32_t);
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return Motor::State::Brake;
     }
 }
@@ -90,9 +92,11 @@ void PwmDataConverter::set_state(const Motor::State state, uint8_t* buffer)
             set_range_value(0x03U, 18U, 2U, 8U, buffer);
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(state)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            std::snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(state));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
     }
 }

--- a/source/SpeedDataConverter.cpp
+++ b/source/SpeedDataConverter.cpp
@@ -94,9 +94,11 @@ Motor::State SpeedDataConverter::get_state(const uint8_t* buffer)
         case 0x03:
             return Motor::State::Brake;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(state)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(state));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             return Motor::State::Coast;
     }
 }
@@ -120,9 +122,11 @@ void SpeedDataConverter::set_state(Motor::State state, uint8_t* buffer)
             set_range_value(0x03U, start, length, buffer_size, buffer);
             break;
         default:
-            Error&            error   = Error::get_instance();
-            const std::string message = "Unknown motor state (" + std::to_string(static_cast<uint32_t>(state)) + ")";
-            error.error(Error::Type::UnknownValue, 0, message.c_str(), __FILE__, __func__, __LINE__);
+            Error&         error          = Error::get_instance();
+            constexpr char message_base[] = "Unknown motor state (%d)";
+            char           message[sizeof(message_base) + Error::max_uint32_t_length];
+            snprintf(message, sizeof(message), message_base, static_cast<uint32_t>(state));
+            error.error(Error::Type::UnknownValue, 0, message, __FILE__, __func__, __LINE__);
             break;
     }
 }

--- a/source/bit.cpp
+++ b/source/bit.cpp
@@ -16,9 +16,6 @@ uint32_t get_range_value(const uint8_t* buffer, const std::size_t buffer_size, c
         char           message[sizeof(message_base) + Error::max_uint32_t_length * 3];
         snprintf(message, sizeof(message), message_base, start, end, (buffer_size * CHAR_BIT) - 1);
         error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
-        // const std::string message = "Range (" + std::to_string(start) + "-" + std::to_string(end) +
-        // ") is out of range (0-" + std::to_string((buffer_size * CHAR_BIT) - 1) + ")";
-        // error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
         return UINT32_MAX;
     }
 

--- a/source/bit.cpp
+++ b/source/bit.cpp
@@ -11,10 +11,14 @@ uint32_t get_range_value(const uint8_t* buffer, const std::size_t buffer_size, c
 {
     auto end = start + value_size - 1;
     if ((buffer_size * CHAR_BIT) < end) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Range (" + std::to_string(start) + "-" + std::to_string(end) +
-                                    ") is out of range (0-" + std::to_string((buffer_size * CHAR_BIT) - 1) + ")";
-        error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Range (%zu-%zu) is out of range (0-%zu)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 3];
+        snprintf(message, sizeof(message), message_base, start, end, (buffer_size * CHAR_BIT) - 1);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
+        // const std::string message = "Range (" + std::to_string(start) + "-" + std::to_string(end) +
+        // ") is out of range (0-" + std::to_string((buffer_size * CHAR_BIT) - 1) + ")";
+        // error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
         return UINT32_MAX;
     }
 
@@ -36,10 +40,11 @@ bool set_range_value(const uint32_t value, const std::size_t start, const std::s
 {
     auto end = start + value_size - 1;
     if ((buffer_size * CHAR_BIT) < end) {
-        Error&            error   = Error::get_instance();
-        const std::string message = "Range (" + std::to_string(start) + "-" + std::to_string(end) +
-                                    ") is out of range (0-" + std::to_string((buffer_size * CHAR_BIT) - 1) + ")";
-        error.warning(Error::Type::IllegalCombination, 0, message.c_str(), __FILE__, __func__, __LINE__);
+        Error&         error          = Error::get_instance();
+        constexpr char message_base[] = "Range (%zu-%zu) is out of range (0-%zu)";
+        char           message[sizeof(message_base) + Error::max_uint32_t_length * 3];
+        snprintf(message, sizeof(message), message_base, start, end, (buffer_size * CHAR_BIT) - 1);
+        error.warning(Error::Type::IllegalCombination, 0, message, __FILE__, __func__, __LINE__);
         return false;
     }
 

--- a/source/mutex.cpp
+++ b/source/mutex.cpp
@@ -1,4 +1,4 @@
-#include <include/mutex.h>
+#include "include/mutex.h"
 
 namespace spirit {
 


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #151

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
#151 のビルドエラーの原因は、NUCLEO_F303K8 のデフォルトの設定では軽量版のライブラリが用いられていることだった

そのライブラリでは std::string で特定の文字列操作を行う場合リンクエラーが発生する

文字列操作は snprintf を利用した文字列操作を行うことにすればビルドエラーが発生しなくなるため、 std::string を利用している箇所を snprintf を利用した文字列操作に変更する

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->

内部処理の変更のため、変更の必要なし

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->

なし