### PR TITLE
fix: mbed-tools のビルドエラーを修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 if(DEFINED MBED_PATH)
-    add_compile_definitions(SPIRIT_TARGET=MBED)
+    add_compile_definitions(SPIRIT_MBED=1)
 
     target_link_libraries(spirit mbed-os)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 if(DEFINED MBED_PATH)
+    add_compile_definitions(SPIRIT_TARGET=MBED)
+
+    target_link_libraries(spirit mbed-os)
+
     add_library(spirit-platform-mbed STATIC)
 
     if(MSVC)

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,10 +1,10 @@
 #ifndef SPIRIT_MUTEX_H
 
-#ifdef __MBED__
+#if SPIRIT_TARGET == MBED || defined(__MBED__)
 #include "mbed.h"
 #else
 #include <mutex>
-#endif  // __MBED__
+#endif
 
 namespace spirit {
 
@@ -18,11 +18,11 @@ public:
     void unlock();
 
 private:
-#ifdef __MBED__
+#if SPIRIT_TARGET == MBED || defined(__MBED__)
     Mutex _mutex;
 #else
     std::mutex _mutex;
-#endif  // __MBED__
+#endif
 };
 
 }  // namespace spirit

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,6 +1,6 @@
 #ifndef SPIRIT_MUTEX_H
 
-#if SPIRIT_TARGET == MBED || defined(__MBED__)
+#if SPIRIT_MBED || __MBED__
 #include "mbed.h"
 #else
 #include <mutex>
@@ -18,7 +18,7 @@ public:
     void unlock();
 
 private:
-#if SPIRIT_TARGET == MBED || defined(__MBED__)
+#if SPIRIT_MBED || __MBED__
     Mutex _mutex;
 #else
     std::mutex _mutex;


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- mbed-tools のビルドエラー(https://github.com/yutotnh/mbed-can-motor-driver-for-spirit/pull/11) を修正

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
