### PR TITLE
update: カバレッジ分析ができるようにオプションを追加

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,9 @@ FetchContent_Declare(
     URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
 )
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+
 # 親プロジェクトのコンパイラ・リンカ設定を上書きするのを防ぐ（Windowsのみ）
 if(WIN32)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
カバレッジ分析ができるように `tests/CMakeLists.txt` のコンパイルオプションを追加した。

参考: https://qiita.com/imasaaki/items/0021d1ef14660184f396

あとは、以下のような手順でカバレッジを確認できる

```console
$ cd biuld/tests
$ lcov -d . -c -o coverage.info
$ lcov -r coverage.info */googletest/* test/* */c++/* -o coverageFiltered.info
$ genhtml -o lcovHtml --num-spaces 4 -s --legend coverage.info
## カバレッジを確認できる lcovHtml/index.html ができている
```

![image](https://user-images.githubusercontent.com/57719497/215163676-aabd6d79-4f30-4bab-a64e-7fe3bf3c43dd.png)

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
