### PR TITLE
update: adjust_duty_cycle() を速度制御対応させる #180

### DIFF
--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -33,7 +33,7 @@ void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycl
         return;
     }
 
-    // 現在の回転方向がCoastの場合はデューティー比を0にする
+    // 現在の回転方向がCoast or Brakeの場合は現在のデューティー比を0として扱う
     if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
         current_duty_cycle = 0.00F;
     }

--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -25,15 +25,10 @@ void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycl
                        float max_fall_delta, spirit::Motor::State current_state, float current_duty_cycle,
                        spirit::Motor::State& next_state, float& next_duty_cycle)
 {
-    // Coast <=> Brake, Coast <=> Coast, Brake <=> Brake の場合はデューティー比を0にする
-    if (((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) &&
-        ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake))) {
-        next_state      = target_state;
-        next_duty_cycle = 0.00F;
-        return;
+    // 回転方向がCoast or Brakeの場合は現在のデューティー比を0として扱う
+    if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
+        target_duty_cycle = 0.00F;
     }
-
-    // 現在の回転方向がCoast or Brakeの場合は現在のデューティー比を0として扱う
     if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
         current_duty_cycle = 0.00F;
     }

--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -10,60 +10,50 @@ namespace spirit {
 
 /**
  * @brief モーターのデューティー比を調整する
- * @param target 調整対象のモーター
- * @param current_state 前回の回転方向
- * @param current_duty_cycle 前回のデューティー比
- * @param next_state 次回の回転方向
- * @param next_duty_cycle 次回のデューティー比
+ * @param [in] target_state 目標の回転方向
+ * @param [in] target_duty_cycle 目標のデューティー比
+ * @param [in] max_rise_delta 最大上昇デューティー比
+ * @param [in] max_fall_delta 最大下降デューティー比
+ * @param [in] current_state 前回の回転方向
+ * @param [in] current_duty_cycle 前回のデューティー比
+ * @param [out] next_state 次回の回転方向
+ * @param [out] next_duty_cycle 次回のデューティー比
  */
-void adjust_duty_cycle(const Motor& target, spirit::Motor::State current_state, float current_duty_cycle,
+void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycle, float max_rise_delta,
+                       float max_fall_delta, spirit::Motor::State current_state, float current_duty_cycle,
                        spirit::Motor::State& next_state, float& next_duty_cycle)
 {
-    const float rise_delta = target.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise);
-    const float fall_delta = target.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Fall);
-
     // 回転方向が異なる場合
-    if (current_state != target.get_state()) {
-        if (target.get_change_level(Motor::ChangeLevelTarget::Fall) == Motor::ChangeLevel::OFF) {
-            next_state      = target.get_state();
-            next_duty_cycle = target.get_duty_cycle();
-        } else if (current_duty_cycle <= fall_delta) {
-            next_state = target.get_state();
+    if (current_state != target_state) {
+        if (current_duty_cycle <= max_fall_delta) {
+            next_state = target_state;
             if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
-                next_duty_cycle = rise_delta;
+                next_duty_cycle = max_rise_delta;
             } else {
                 next_duty_cycle = 0.00F;
             }
         } else {
             next_state      = current_state;
-            next_duty_cycle = current_duty_cycle - fall_delta;
+            next_duty_cycle = current_duty_cycle - max_fall_delta;
         }
 
         return;
     }
 
     // 以降の処理は回転方向が同じ場合ということなので、次の回転方向を設定する
-    next_state = target.get_state();
+    next_state = target_state;
 
     // 設定値の方が現在のデューティー比より大きい場合
-    if ((target.get_duty_cycle() - current_duty_cycle) >= rise_delta) {
-        if (target.get_change_level(Motor::ChangeLevelTarget::Rise) == Motor::ChangeLevel::OFF) {
-            next_duty_cycle = target.get_duty_cycle();
-        } else {
-            next_duty_cycle = current_duty_cycle + rise_delta;
-        }
+    if ((target_duty_cycle - current_duty_cycle) >= max_rise_delta) {
+        next_duty_cycle = current_duty_cycle + max_rise_delta;
     }
     // 設定値の方が現在のデューティー比より小さい場合
-    else if ((target.get_duty_cycle() - current_duty_cycle) <= -fall_delta) {
-        if (target.get_change_level(Motor::ChangeLevelTarget::Fall) == Motor::ChangeLevel::OFF) {
-            next_duty_cycle = target.get_duty_cycle();
-        } else {
-            next_duty_cycle = current_duty_cycle - fall_delta;
-        }
+    else if ((target_duty_cycle - current_duty_cycle) <= -max_fall_delta) {
+        next_duty_cycle = current_duty_cycle - max_fall_delta;
     }
     // 設定値と現在のデューティー比が一緒 or ほぼ一緒の時
     else {
-        next_duty_cycle = target.get_duty_cycle();
+        next_duty_cycle = target_duty_cycle;
     }
 }
 

--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -18,6 +18,8 @@ namespace spirit {
  * @param [in] current_duty_cycle 現在のデューティー比
  * @param [out] next_state 次の回転方向
  * @param [out] next_duty_cycle 次のデューティー比
+ * @note
+ * Motor::State::Coast, Motor::State::Brake は必ずデューティー比を0として扱う
  */
 void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycle, float max_rise_delta,
                        float max_fall_delta, spirit::Motor::State current_state, float current_duty_cycle,
@@ -31,11 +33,16 @@ void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycl
         return;
     }
 
+    // 現在の回転方向がCoastの場合はデューティー比を0にする
+    if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
+        current_duty_cycle = 0.00F;
+    }
+
     // 現在の回転方向と目標の回転方向が異なる場合
     if (current_state != target_state) {
         if (current_duty_cycle <= max_fall_delta) {
             next_state      = target_state;
-            next_duty_cycle = max_rise_delta;
+            next_duty_cycle = 0.00F;
         } else {
             next_state      = current_state;
             next_duty_cycle = current_duty_cycle - max_fall_delta;

--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -23,15 +23,19 @@ void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycl
                        float max_fall_delta, spirit::Motor::State current_state, float current_duty_cycle,
                        spirit::Motor::State& next_state, float& next_duty_cycle)
 {
-    // 回転方向が異なる場合
+    // Coast <=> Brake, Coast <=> Coast, Brake <=> Brake の場合はデューティー比を0にする
+    if (((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) &&
+        ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake))) {
+        next_state      = target_state;
+        next_duty_cycle = 0.00F;
+        return;
+    }
+
+    // 現在の回転方向と目標の回転方向が異なる場合
     if (current_state != target_state) {
         if (current_duty_cycle <= max_fall_delta) {
-            next_state = target_state;
-            if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
-                next_duty_cycle = max_rise_delta;
-            } else {
-                next_duty_cycle = 0.00F;
-            }
+            next_state      = target_state;
+            next_duty_cycle = max_rise_delta;
         } else {
             next_state      = current_state;
             next_duty_cycle = current_duty_cycle - max_fall_delta;

--- a/include/adjust_duty_cycle.h
+++ b/include/adjust_duty_cycle.h
@@ -14,10 +14,10 @@ namespace spirit {
  * @param [in] target_duty_cycle 目標のデューティー比
  * @param [in] max_rise_delta 最大上昇デューティー比
  * @param [in] max_fall_delta 最大下降デューティー比
- * @param [in] current_state 前回の回転方向
- * @param [in] current_duty_cycle 前回のデューティー比
- * @param [out] next_state 次回の回転方向
- * @param [out] next_duty_cycle 次回のデューティー比
+ * @param [in] current_state 現在の回転方向
+ * @param [in] current_duty_cycle 現在のデューティー比
+ * @param [out] next_state 次の回転方向
+ * @param [out] next_duty_cycle 次のデューティー比
  */
 void adjust_duty_cycle(spirit::Motor::State target_state, float target_duty_cycle, float max_rise_delta,
                        float max_fall_delta, spirit::Motor::State current_state, float current_duty_cycle,

--- a/source/Motor.cpp
+++ b/source/Motor.cpp
@@ -212,9 +212,9 @@ float Motor::get_maximum_change_duty_cycle(ChangeLevelTarget target) const
         case ChangeLevel::Middle:
             return 0.0001F;
         case ChangeLevel::High:
-            return 0.00001F;
+            return 0.0001F;
         case ChangeLevel::Max:
-            return 0.000001F;
+            return 0.00001F;
         default:
             Error&         error            = Error::get_instance();
             constexpr char message_format[] = "Unknown motor change level (%d)";

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -96,6 +96,12 @@ TEST(AdjustDutyCycle, DifferentState)
                           motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
                           motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
                           current_duty_cycle, next_state, next_duty_cycle);
+        current_state      = next_state;
+        current_duty_cycle = next_duty_cycle;
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle,
                         current_duty_cycle + motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise));
@@ -174,8 +180,8 @@ TEST(AdjustDutyCycle, SameState)
         // 最後にデューティー比が目標値に達していることを確認する(上昇)
         current_state      = Motor::State::CW;
         current_duty_cycle = 0.60F;
-        std::size_t count  = fabs(motor.get_duty_cycle() - current_duty_cycle) /
-                            motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise);
+        std::size_t count  = std::ceil(fabs(motor.get_duty_cycle() - current_duty_cycle) /
+                                       motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise));
 
         // デューティー比が目標値に達するまでループ
         for (std::size_t i = 0; i < count; i++) {
@@ -264,6 +270,104 @@ TEST(AdjustDutyCycle, ManualChangeLevel)
                           current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle, current_duty_cycle + change_level_rise);
+    }
+}
+
+/**
+ * @brief 正常系のテスト @n
+ * 最終的にデューティー比が目標値まで達することの確認 @n
+ * 途中経過や、特定の回数できっかり目標値に達成するかは気にしない
+ */
+TEST(AdjustDutyCycle, Normal)
+{
+    auto test = [](const Motor::State target_state, const float target_duty_cycle, const float max_rise_delta,
+                   const float max_fall_delta, const Motor::State current_state, const float current_duty_cycle,
+                   const Motor::State expected_state, const float expected_duty_cycle, const size_t loop_count) {
+        Motor motor;
+        motor.control_system(Motor::ControlSystem::PWM);
+        motor.state(target_state);
+        motor.duty_cycle(target_duty_cycle);
+
+        motor.change_level(Motor::ChangeLevelTarget::Rise, max_rise_delta);
+        motor.change_level(Motor::ChangeLevelTarget::Fall, max_fall_delta);
+
+        Motor::State current_state_for_loop      = current_state;
+        float        current_duty_cycle_for_loop = current_duty_cycle;
+        Motor::State next_state;
+        float        next_duty_cycle;
+
+        for (size_t i = 0; i < loop_count; i++) {
+            adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall),
+                              current_state_for_loop, current_duty_cycle_for_loop, next_state, next_duty_cycle);
+            current_state_for_loop      = next_state;
+            current_duty_cycle_for_loop = next_duty_cycle;
+        }
+
+        EXPECT_EQ(next_state, expected_state)
+            << "target_state: " << static_cast<int>(target_state) << ", target_duty_cycle: " << target_duty_cycle
+            << ", max_rise_delta: " << max_rise_delta << ", max_fall_delta: " << max_fall_delta
+            << ", current_state(argument): " << static_cast<int>(current_state)
+            << ", current_duty_cycle(argument): " << current_duty_cycle
+            << ", current_state(previous): " << static_cast<int>(current_state)
+            << ", current_duty_cycle(previous): " << current_duty_cycle
+            << ", expected_state: " << static_cast<int>(expected_state)
+            << ", expected_duty_cycle: " << expected_duty_cycle << ", loop_count: " << loop_count;
+        EXPECT_FLOAT_EQ(next_duty_cycle, expected_duty_cycle)
+            << "target_state: " << static_cast<int>(target_state) << ", target_duty_cycle: " << target_duty_cycle
+            << ", max_rise_delta: " << max_rise_delta << ", max_fall_delta: " << max_fall_delta
+            << ", current_state(argument): " << static_cast<int>(current_state)
+            << ", current_duty_cycle(argument): " << current_duty_cycle
+            << ", current_state(previous): " << static_cast<int>(current_state)
+            << ", current_duty_cycle(previous): " << current_duty_cycle
+            << ", expected_state: " << static_cast<int>(expected_state)
+            << ", expected_duty_cycle: " << expected_duty_cycle << ", loop_count: " << loop_count;
+    };
+
+    float        duty_cycles[] = {0.00F, 0.30F, 1.00F};
+    Motor::State states[]      = {Motor::State::Coast, Motor::State::CW, Motor::State::CCW, Motor::State::Brake};
+
+    auto max_delta = [](Motor::ChangeLevel level) -> float {
+        Motor motor;
+        motor.control_system(Motor::ControlSystem::PWM);
+        motor.change_level(Motor::ChangeLevelTarget::Rise, level);
+        return motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise);
+    };
+
+    float max_deltas[] = {max_delta(Motor::ChangeLevel::OFF),    max_delta(Motor::ChangeLevel::Low),
+                          max_delta(Motor::ChangeLevel::Middle), max_delta(Motor::ChangeLevel::High),
+                          max_delta(Motor::ChangeLevel::Max),    0.50F};
+
+    // 最終的にデューティー比が目標値まで達することの確認
+    // 途中経過や、特定の回数できっかり目標値に達成するかは気にしない
+    {
+        for (auto target_duty_cycle : duty_cycles) {
+            for (auto target_state : states) {
+                for (auto max_rise_delta : max_deltas) {
+                    for (auto max_fall_delta : max_deltas) {
+                        for (auto current_duty_cycle : duty_cycles) {
+                            for (auto current_state : states) {
+                                // 回転方向がCoastまたはBrakeの場合デューティー比は0になるのでテストをスキップする
+                                if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
+                                    continue;
+                                }
+
+                                // max_rise_delta と max_fall_delta の小さいほうを使用する
+                                float delta = std::min(max_rise_delta, max_fall_delta);
+                                // 100% -> 0% -> 100% の場合のループ回数を計算する
+                                uint32_t loop_count = static_cast<uint32_t>(std::ceil(1.00F / delta)) * 2;
+                                // 浮動小数点数の誤差を考慮して、ループの回数を1.1倍にする(1.01倍は適当)
+                                loop_count = static_cast<uint32_t>(std::ceil(loop_count * 1.01F));
+
+                                test(target_state, target_duty_cycle, max_rise_delta, max_fall_delta, current_state,
+                                     current_duty_cycle, target_state, target_duty_cycle, loop_count);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -18,6 +18,8 @@ TEST(AdjustDutyCycle, DifferentState)
         motor.control_system(Motor::ControlSystem::PWM);
         motor.state(Motor::State::CW);
         motor.duty_cycle(0.80F);
+        motor.change_level(Motor::ChangeLevelTarget::Fall, Motor::ChangeLevel::OFF);
+        motor.change_level(Motor::ChangeLevelTarget::Rise, Motor::ChangeLevel::OFF);
 
         Motor::State current_state;
         float        current_duty_cycle;
@@ -28,13 +30,35 @@ TEST(AdjustDutyCycle, DifferentState)
         current_state      = Motor::State::CCW;
         current_duty_cycle = 0.80F;
 
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        // デューティー比と回転方向の変化は2段階で起きる
+        // そのため、2回 adjust_duty_cycle() を呼び出す
+        // - 1段階目 ... 回転方向の変化
+        // - 2段階目 ... デューティー比の変化
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
+        current_state      = next_state;
+        current_duty_cycle = next_duty_cycle;
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle, motor.get_duty_cycle());
 
         current_state      = Motor::State::Brake;
         current_duty_cycle = 0.00F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
+        current_state      = next_state;
+        current_duty_cycle = next_duty_cycle;
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle, motor.get_duty_cycle());
     }
@@ -57,7 +81,10 @@ TEST(AdjustDutyCycle, DifferentState)
         // CW状態から、Stateとデューティー比が変化することの確認
         current_state      = Motor::State::CCW;
         current_duty_cycle = 0.80F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle,
                         current_duty_cycle - motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Fall));
@@ -65,7 +92,10 @@ TEST(AdjustDutyCycle, DifferentState)
         // Brake状態から、Stateとデューティー比が変化することの確認
         current_state      = Motor::State::Brake;
         current_duty_cycle = 0.00F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle,
                         current_duty_cycle + motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise));
@@ -83,6 +113,8 @@ TEST(AdjustDutyCycle, SameState)
         motor.control_system(Motor::ControlSystem::PWM);
         motor.state(Motor::State::CW);
         motor.duty_cycle(0.80F);
+        motor.change_level(Motor::ChangeLevelTarget::Fall, Motor::ChangeLevel::OFF);
+        motor.change_level(Motor::ChangeLevelTarget::Rise, Motor::ChangeLevel::OFF);
 
         Motor::State current_state;
         float        current_duty_cycle;
@@ -93,13 +125,19 @@ TEST(AdjustDutyCycle, SameState)
         current_state      = Motor::State::CW;
         current_duty_cycle = 1.00F;
 
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle, motor.get_duty_cycle());
 
         current_state      = Motor::State::CW;
         current_duty_cycle = 0.10F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, motor.get_state());
         EXPECT_FLOAT_EQ(next_duty_cycle, motor.get_duty_cycle());
     }
@@ -125,7 +163,10 @@ TEST(AdjustDutyCycle, SameState)
         // 次のデューティー比は現在デューティー比 + 最大上昇変化量 になる
         current_state      = Motor::State::CW;
         current_duty_cycle = 0.70F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle,
                         current_duty_cycle + motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Rise));
@@ -141,7 +182,10 @@ TEST(AdjustDutyCycle, SameState)
             // ほんとはループ中にデューティー比が目標値に達しているか確認するべきだが、
             // 浮動小数点の誤差があるので、最後の何回かはFAILしてしまう
             // なので、ループの最後でのみ確認する
-            adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+            adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall),
+                              current_state, current_duty_cycle, next_state, next_duty_cycle);
             current_duty_cycle = next_duty_cycle;
         }
         EXPECT_EQ(next_state, motor.get_state());
@@ -150,7 +194,10 @@ TEST(AdjustDutyCycle, SameState)
         // 目標 - 現在 > - 最大下降変化量
         current_state      = Motor::State::CW;
         current_duty_cycle = 0.90F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle,
                         current_duty_cycle - motor.get_maximum_change_duty_cycle(Motor::ChangeLevelTarget::Fall));
@@ -164,7 +211,10 @@ TEST(AdjustDutyCycle, SameState)
             // ほんとはループ中にデューティー比が目標値に達しているか確認するべきだが、
             // 浮動小数点の誤差があるので、最後の何回かはFAILしてしまう
             // なので、ループの最後でのみ確認する
-            adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+            adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                              motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall),
+                              current_state, current_duty_cycle, next_state, next_duty_cycle);
             current_duty_cycle = next_duty_cycle;
         }
         EXPECT_EQ(next_state, motor.get_state());
@@ -199,13 +249,19 @@ TEST(AdjustDutyCycle, ManualChangeLevel)
         current_state      = Motor::State::CW;
         current_duty_cycle = 1.00F;
 
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle, current_duty_cycle - change_level_fall);
 
         current_state      = Motor::State::CW;
         current_duty_cycle = 0.50F;
-        adjust_duty_cycle(motor, current_state, current_duty_cycle, next_state, next_duty_cycle);
+        adjust_duty_cycle(motor.get_state(), motor.get_duty_cycle(),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Rise),
+                          motor.get_maximum_change_duty_cycle(spirit::Motor::ChangeLevelTarget::Fall), current_state,
+                          current_duty_cycle, next_state, next_duty_cycle);
         EXPECT_EQ(next_state, current_state);
         EXPECT_FLOAT_EQ(next_duty_cycle, current_duty_cycle + change_level_rise);
     }

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -346,12 +346,10 @@ TEST(AdjustDutyCycle, Normal)
                 for (auto max_fall_delta : max_deltas) {
                     for (auto current_duty_cycle : duty_cycles) {
                         for (auto current_state : states) {
-                            // 回転方向がCoastまたはBrakeの場合デューティー比は0として扱う
+                            // 回転方向がCoastまたはBrakeの場合デューティー比は0として扱うので、目標値を0にする
+                            float expected_duty_cycle = target_duty_cycle;
                             if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
-                                target_duty_cycle = 0.00F;
-                            }
-                            if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
-                                current_duty_cycle = 0.00F;
+                                expected_duty_cycle = 0.00F;
                             }
 
                             // max_rise_delta と max_fall_delta の小さいほうを使用する
@@ -362,7 +360,7 @@ TEST(AdjustDutyCycle, Normal)
                             loop_count = static_cast<uint32_t>(std::ceil(loop_count * 1.01F));
 
                             test(target_state, target_duty_cycle, max_rise_delta, max_fall_delta, current_state,
-                                 current_duty_cycle, target_state, target_duty_cycle, loop_count);
+                                 current_duty_cycle, target_state, expected_duty_cycle, loop_count);
                         }
                     }
                 }

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -325,7 +325,8 @@ TEST(AdjustDutyCycle, Normal)
             << ", expected_duty_cycle: " << expected_duty_cycle << ", loop_count: " << loop_count;
     };
 
-    float        duty_cycles[] = {0.00F, 0.30F, 1.00F};
+    // 実行時間の関係で、テストケースは最小限にする
+    float        duty_cycles[] = {0.00F, 0.345F, 1.00F};
     Motor::State states[]      = {Motor::State::Coast, Motor::State::CW, Motor::State::CCW, Motor::State::Brake};
 
     auto max_delta = [](Motor::ChangeLevel level) -> float {
@@ -337,32 +338,28 @@ TEST(AdjustDutyCycle, Normal)
 
     float max_deltas[] = {max_delta(Motor::ChangeLevel::OFF),    max_delta(Motor::ChangeLevel::Low),
                           max_delta(Motor::ChangeLevel::Middle), max_delta(Motor::ChangeLevel::High),
-                          max_delta(Motor::ChangeLevel::Max),    0.50F};
+                          max_delta(Motor::ChangeLevel::Max),    0.567F};
 
-    // 最終的にデューティー比が目標値まで達することの確認
-    // 途中経過や、特定の回数できっかり目標値に達成するかは気にしない
-    {
-        for (auto target_duty_cycle : duty_cycles) {
-            for (auto target_state : states) {
-                for (auto max_rise_delta : max_deltas) {
-                    for (auto max_fall_delta : max_deltas) {
-                        for (auto current_duty_cycle : duty_cycles) {
-                            for (auto current_state : states) {
-                                // 回転方向がCoastまたはBrakeの場合デューティー比は0になるのでテストをスキップする
-                                if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
-                                    continue;
-                                }
-
-                                // max_rise_delta と max_fall_delta の小さいほうを使用する
-                                float delta = std::min(max_rise_delta, max_fall_delta);
-                                // 100% -> 0% -> 100% の場合のループ回数を計算する
-                                uint32_t loop_count = static_cast<uint32_t>(std::ceil(1.00F / delta)) * 2;
-                                // 浮動小数点数の誤差を考慮して、ループの回数を1.1倍にする(1.01倍は適当)
-                                loop_count = static_cast<uint32_t>(std::ceil(loop_count * 1.01F));
-
-                                test(target_state, target_duty_cycle, max_rise_delta, max_fall_delta, current_state,
-                                     current_duty_cycle, target_state, target_duty_cycle, loop_count);
+    for (auto target_duty_cycle : duty_cycles) {
+        for (auto target_state : states) {
+            for (auto max_rise_delta : max_deltas) {
+                for (auto max_fall_delta : max_deltas) {
+                    for (auto current_duty_cycle : duty_cycles) {
+                        for (auto current_state : states) {
+                            // 回転方向がCoastまたはBrakeの場合デューティー比は0になるのでテストをスキップする
+                            if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
+                                continue;
                             }
+
+                            // max_rise_delta と max_fall_delta の小さいほうを使用する
+                            float delta = std::min(max_rise_delta, max_fall_delta);
+                            // 100% -> 0% -> 100% の場合のループ回数を計算する
+                            uint32_t loop_count = static_cast<uint32_t>(std::ceil(1.00F / delta)) * 2;
+                            // 浮動小数点数の誤差を考慮して、ループの回数を1.1倍にする(1.01倍は適当)
+                            loop_count = static_cast<uint32_t>(std::ceil(loop_count * 1.01F));
+
+                            test(target_state, target_duty_cycle, max_rise_delta, max_fall_delta, current_state,
+                                 current_duty_cycle, target_state, target_duty_cycle, loop_count);
                         }
                     }
                 }

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -346,9 +346,12 @@ TEST(AdjustDutyCycle, Normal)
                 for (auto max_fall_delta : max_deltas) {
                     for (auto current_duty_cycle : duty_cycles) {
                         for (auto current_state : states) {
-                            // 回転方向がCoastまたはBrakeの場合デューティー比は0になるのでテストをスキップする
+                            // 回転方向がCoastまたはBrakeの場合デューティー比は0として扱う
                             if ((target_state == Motor::State::Coast) || (target_state == Motor::State::Brake)) {
-                                continue;
+                                target_duty_cycle = 0.00F;
+                            }
+                            if ((current_state == Motor::State::Coast) || (current_state == Motor::State::Brake)) {
+                                current_duty_cycle = 0.00F;
                             }
 
                             // max_rise_delta と max_fall_delta の小さいほうを使用する


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #180

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
- 機能変更: adjust_duty_cycle の Motor クラスの引数の部分をデューティー比、回転方向、上昇の最大値、下降の最大値に変える
  -  速度制御時は、Motorクラスでは目標値を持っていないため、引数を変更する必要がった
- バグ修正: 以下の部分が下降のChengeLevelのみ見ていたのが原因で、 motor.change_level(Motor::ChangeLevelTarget::Fall, Motor::ChangeLevel::OFF) のとき、回転方向を変える際上昇のChangeLevelを無視して回転方向とデューティー比をすぐに目標値を設定するようになっていたバグを修正
https://github.com/yutotnh/spirit/blob/62dd6467d199d7455a4ade670a203816b6d399a1/include/adjust_duty_cycle.h#L25-L30

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
本修正でテスト対象の引数と動作が変化したので、修正した

テストも、様々な組み合わせで最終的にデューティー比へ到達することを確認するものを追加した

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
異常系の制御の追加やテストの追加は #186 で対応する