### PR TITLE
spirit::Motor::ChangeLevel::Manual で設定可能な最小値を下回ったらエラーを出力する

### DIFF
--- a/include/Error.h
+++ b/include/Error.h
@@ -50,6 +50,11 @@ public:
     static Error& get_instance();
 
     /**
+     * @brief エラー状態をリセットする
+     */
+    void reset();
+
+    /**
      * @brief エラー状態を取得する
      * @return エラー状態
      */

--- a/include/Motor.h
+++ b/include/Motor.h
@@ -296,7 +296,7 @@ public:
 
     /// デューティ比の変化具合の最小値 @n
     /// Float 型の 1.00 に対してこれよりも小さい値を足しても、情報落ちして 1.00 より大きくならない
-    static constexpr float minimum_maximum_change_duty_cycle = pow(2.0F, -23);
+    static constexpr float minimum_maximum_change_duty_cycle = std::pow(2.0F, -23.0F);
 
 private:
     ControlSystem _control_system{Default::control_system};

--- a/include/Motor.h
+++ b/include/Motor.h
@@ -1,6 +1,7 @@
 #ifndef SPIRIT_MOTOR_H
 #define SPIRIT_MOTOR_H
 
+#include <cmath>
 #include <cstdint>
 
 namespace spirit {
@@ -292,6 +293,10 @@ public:
 
     static constexpr float min_pulse_period = 1.0F / 60'000.0F;
     static constexpr float max_pulse_period = 1.0F / 10.0F;
+
+    /// デューティ比の変化具合の最小値 @n
+    /// Float 型の 1.00 に対してこれよりも小さい値を足しても、情報落ちして 1.00 より大きくならない
+    static constexpr float minimum_maximum_change_duty_cycle = pow(2.0F, -23);
 
 private:
     ControlSystem _control_system{Default::control_system};

--- a/include/Motor.h
+++ b/include/Motor.h
@@ -296,7 +296,7 @@ public:
 
     /// デューティ比の変化具合の最小値 @n
     /// Float 型の 1.00 に対してこれよりも小さい値を足しても、情報落ちして 1.00 より大きくならない
-    static constexpr float minimum_maximum_change_duty_cycle = std::pow(2.0F, -23.0F);
+    static constexpr float minimum_maximum_change_duty_cycle = 0.00000011920928955078125F;  // std::pow(2.0F, -23.0F)
 
 private:
     ControlSystem _control_system{Default::control_system};

--- a/include/Motor.h
+++ b/include/Motor.h
@@ -1,7 +1,6 @@
 #ifndef SPIRIT_MOTOR_H
 #define SPIRIT_MOTOR_H
 
-#include <cmath>
 #include <cstdint>
 
 namespace spirit {

--- a/source/Error.cpp
+++ b/source/Error.cpp
@@ -14,6 +14,11 @@ Error& Error::get_instance()
     return instance;
 }
 
+void Error::reset()
+{
+    _status = Status::Normal;
+}
+
 Error::Status Error::get_status()
 {
     return _status;

--- a/source/Motor.cpp
+++ b/source/Motor.cpp
@@ -145,6 +145,15 @@ void Motor::change_level(const ChangeLevelTarget target, const ChangeLevel level
 
 void Motor::change_level(const ChangeLevelTarget target, const float duty_cycle)
 {
+    if (duty_cycle < minimum_maximum_change_duty_cycle) {
+        Error&         error            = Error::get_instance();
+        constexpr char message_format[] = "Duty cycle (%1.4e) is less than minimum duty cycle (%1.4e)";
+        char           message[sizeof(message_format) + Error::max_float_1_4_e_length * 2];
+        snprintf(message, sizeof(message), message_format, duty_cycle, minimum_maximum_change_duty_cycle);
+        error.error(Error::Type::InvalidValue, 0, message, __FILE__, __func__, __LINE__);
+        return;
+    }
+
     switch (target) {
         case ChangeLevelTarget::Rise:
             _rise_change_level              = ChangeLevel::Manual;

--- a/tests/test_Error.cpp
+++ b/tests/test_Error.cpp
@@ -26,6 +26,10 @@ TEST(Error, ErrorTest)
     error.error(spirit::Error::Type::UnknownValue, 0, "test", __FILE__, __func__, __LINE__);
     EXPECT_EQ(error.get_status(), spirit::Error::Status::Error);
 
+    /// @test reset が呼ばれたら、エラー状態が Normal になる
+    error.reset();
+    EXPECT_EQ(error.get_status(), spirit::Error::Status::Normal);
+
     /// @test 目視確認
     error.warning(spirit::Error::Type::IllegalCombination, 10, "Illegal combination1", __FILE__, __func__, __LINE__);
     error.error(spirit::Error::Type::IllegalCombination, 10, "Illegal combination2", __FILE__, __func__, __LINE__);


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #185

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
Issueに記載の内容 + Errorの修正

Erorrの修正内容

今までエラー状態が一度WarningやErrorになったらNormalに戻ることがなかったので、Normalに戻すようにしてテストケースごとにきちんとエラー状態がNormalからError(Warning)になることを確認する

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
- Errorに追加した関数(reset)用のテストを追加
- spirit::Motor::ChangeLevel::Manual で設定可能な最小値を下回ったらエラーを出力することを確認するテストを追加


## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
