### PR TITLE
update: テスト時間の短縮 & コンパイラによる警告を減らす

### DIFF
--- a/tests/integration_test.cpp
+++ b/tests/integration_test.cpp
@@ -22,7 +22,7 @@ TEST(IntegrationTest, 1)
     constexpr uint32_t dip_sw = 0x00;
 
     /// 送信側
-    auto controller = [&dip_sw](const spirit::Motor &motor) {
+    auto controller = [dip_sw](const spirit::Motor &motor) {
         spirit::FakeUdpConverter   fake_udp;
         spirit::MotorDataConverter motor_data;
         const uint32_t             can_id = spirit::can::get_motor_id(1, 0, dip_sw);
@@ -54,7 +54,7 @@ TEST(IntegrationTest, 1)
     };
 
     /// 受信側
-    auto peripheral = [&dip_sw](const ::CANMessage &message) {
+    auto peripheral = [dip_sw](const ::CANMessage &message) {
         spirit::FakeUdpConverter   fake_udp;
         spirit::MotorDataConverter motor_data;
 

--- a/tests/test_PwmDataConverter.cpp
+++ b/tests/test_PwmDataConverter.cpp
@@ -92,7 +92,6 @@ TEST(PwmDataConverter, EncodeBufferSizeTest)
 {
     auto buffer_size_test = [](std::size_t encode_buffer_size, bool expected_is_succeeded) {
         PwmDataConverter pwm_data_converter;
-        Motor            motor;
 
         constexpr std::size_t max_buffer_size = 8;
         uint8_t               buffer[max_buffer_size]{};

--- a/tests/test_adjust_duty_cycle.cpp
+++ b/tests/test_adjust_duty_cycle.cpp
@@ -352,12 +352,18 @@ TEST(AdjustDutyCycle, Normal)
                                 expected_duty_cycle = 0.00F;
                             }
 
-                            // max_rise_delta と max_fall_delta の小さいほうを使用する
-                            float delta = std::min(max_rise_delta, max_fall_delta);
-                            // 100% -> 0% -> 100% の場合のループ回数を計算する
-                            uint32_t loop_count = static_cast<uint32_t>(std::ceil(1.00F / delta)) * 2;
+                            // current_duty_cycle -> 0% -> target_duty_cycle の場合のループ回数を計算する
+                            uint32_t loop_count = static_cast<uint32_t>(std::ceil(current_duty_cycle / max_fall_delta) +
+                                                                        std::ceil(target_duty_cycle / max_rise_delta));
                             // 浮動小数点数の誤差を考慮して、ループの回数を1.1倍にする(1.01倍は適当)
                             loop_count = static_cast<uint32_t>(std::ceil(loop_count * 1.01F));
+
+                            // current_duty_cycle == target_duty_cycle == 0.0F の場合はループ回数が0になるので、
+                            // adjust_duty_cycle() が実行されず回転方向が変わらなくなる
+                            // そのため、ループ回数が0の場合は1にする
+                            if (loop_count == 0) {
+                                loop_count = 1;
+                            }
 
                             test(target_state, target_duty_cycle, max_rise_delta, max_fall_delta, current_state,
                                  current_duty_cycle, target_state, expected_duty_cycle, loop_count);


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
- AdjustDutyCycle.Normal のテスト時間を約1/4に縮小した
- コンパイラが出す警告を減らした

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
- テストコード自体は変更したが、テストケースに関しては変更していない

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
