### PR TITLE
fix: spiritライブラリを Mbed CLI 2 でビルドしていない問題を修正した #112

### DIFF
--- a/.github/workflows/build-mbed-tools/CMakeLists.txt
+++ b/.github/workflows/build-mbed-tools/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET build-mbed-tools)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+
+add_subdirectory(spirit)
+
+add_executable(${APP_TARGET}
+    main.cpp
+)
+
+target_link_libraries(${APP_TARGET} mbed-os spirit spirit-platform-mbed)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
       - name: build-mbed-tools
         run: |
           set -e
+          cd ..
           mbed-tools new .
+          cp spirit/.github/workflows/build-mbed-tools/CMakeLists.txt CMakeLists.txt
           mbed-tools deploy
           mbed-tools compile -t GCC_ARM -m ${{ matrix.target }} --profile ${{ matrix.profile }}


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #112

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
Issueの記載の通り

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
今まで `build-mbed-tools` では mbed-os のみビルドしていたが、 spirit もビルドするようにした

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし