### PR TITLE
fix: マクロ定義されているかを if のみから、 if + defined で確認する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 if(DEFINED MBED_PATH)
-    add_compile_definitions(SPIRIT_MBED=1)
-
     target_link_libraries(spirit mbed-os)
 
     add_library(spirit-platform-mbed STATIC)

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,7 +1,7 @@
 #ifndef SPIRIT_MUTEX_H
 #define SPIRIT_MUTEX_H
 
-#if SPIRIT_MBED || __MBED__
+#if defined(SPIRIT_MBED) || defined(__MBED__)
 #include "mbed.h"
 #else
 #include <mutex>
@@ -19,7 +19,7 @@ public:
     void unlock();
 
 private:
-#if SPIRIT_MBED || __MBED__
+#if defined(SPIRIT_MBED) || defined(__MBED__)
     Mutex _mutex;
 #else
     std::mutex _mutex;

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,7 +1,7 @@
 #ifndef SPIRIT_MUTEX_H
 #define SPIRIT_MUTEX_H
 
-#if defined(SPIRIT_MBED) || defined(__MBED__)
+#ifdef __MBED__
 #include "mbed.h"
 #else
 #include <mutex>
@@ -19,7 +19,7 @@ public:
     void unlock();
 
 private:
-#if defined(SPIRIT_MBED) || defined(__MBED__)
+#ifdef __MBED__
     Mutex _mutex;
 #else
     std::mutex _mutex;

--- a/spirit.h
+++ b/spirit.h
@@ -18,7 +18,7 @@
 #include "include/bit.h"
 #include "include/mutex.h"
 
-#ifdef MBED_H
+#if defined(SPIRIT_MBED) || defined(__MBED__)
 #include "platform/mbed/include/DigitalOut.h"
 #include "platform/mbed/include/PwmOut.h"
 #endif  // MBED_H

--- a/spirit.h
+++ b/spirit.h
@@ -18,7 +18,7 @@
 #include "include/bit.h"
 #include "include/mutex.h"
 
-#if defined(SPIRIT_MBED) || defined(__MBED__)
+#ifdef __MBED__
 #include "platform/mbed/include/DigitalOut.h"
 #include "platform/mbed/include/PwmOut.h"
 #endif  // MBED_H


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->

マクロ定義されているかを if のみから、 if + defined で確認する

マクロ定義されているかを意図した処理のため、より意図に近い if + defined にした

また、今回の問題が原因で定義していた SPIRIT_MBED マクロの定義を削除した

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし