### PR TITLE
update: ステータスバッジを表示するブランチを"main"に統一した

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 [![Build spirit](https://github.com/yutotnh/spirit/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/yutotnh/spirit/actions/workflows/build.yml)
 [![Testing With CMake and CTest](https://github.com/yutotnh/spirit/actions/workflows/cmake-test.yml/badge.svg?branch=main)](https://github.com/yutotnh/spirit/actions/workflows/cmake-test.yml)
-[![CodeQL](https://github.com/yutotnh/spirit/actions/workflows/codeql.yml/badge.svg)](https://github.com/yutotnh/spirit/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/yutotnh/spirit/actions/workflows/codeql.yml/badge.svg?=branch=main)](https://github.com/yutotnh/spirit/actions/workflows/codeql.yml)
 
-[![Dependency Review](https://github.com/yutotnh/spirit/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/yutotnh/spirit/actions/workflows/dependency-review.yml)
-[![Deploy static content to Pages](https://github.com/yutotnh/spirit/actions/workflows/deploy-static.yml/badge.svg)](https://github.com/yutotnh/spirit/actions/workflows/deploy-static.yml)
+[![Dependency Review](https://github.com/yutotnh/spirit/actions/workflows/dependency-review.yml/badge.svg?=branch=main)](https://github.com/yutotnh/spirit/actions/workflows/dependency-review.yml)
+[![Deploy static content to Pages](https://github.com/yutotnh/spirit/actions/workflows/deploy-static.yml/badge.svg?=branch=main)](https://github.com/yutotnh/spirit/actions/workflows/deploy-static.yml)
 
 </div>
 


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
タイトルの通り

恐らく今まで、`main`ブランチ以外でActionがフェイルしたときに、README.mdに記載しているステータスバッジに反映される場合があった

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
なし

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし