### PR TITLE
fix: 不必要な`set -e`を削除した

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: build-mbed-cli
         run: |
-          set -e
           mbed new .
           mbed deploy
           cp .github/workflows/build-mbed/main.cpp .
@@ -65,7 +64,6 @@ jobs:
 
       - name: build-mbed-tools
         run: |
-          set -e
           cd ..
           mbed-tools new .
           cp spirit/.github/workflows/build-mbed/main.cpp .


### PR DESCRIPTION
元々GitHub Actionsでは終了ステータスが0以外だと、ワークフロー終了する
`set -e`も同様のことをする目的で実行しているため必要ない

## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- なし

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
タイトルの通り

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
`set -e`を削除した

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし